### PR TITLE
Simplify install_requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.7"
 
 install:
-  - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 
 install:
   - pip install -r requirements-dev.txt
+  - pip install -e .
 
 script:
   - .travis/style_checks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-python-dateutil>2.7.0

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,6 @@ from os.path import (
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(here, 'requirements.txt')) as f:
-    install_requires = f.read().split('\n')
-
 with open(os.path.join(here, 'README.md')) as readme_file:
     readme = readme_file.read()
 
@@ -30,7 +27,7 @@ setup(
     packages=find_packages(),
     py_modules=[splitext(basename(path))[0] for path in glob('pystac/*.py')],
     include_package_data=False,
-    install_requires=install_requires,
+    install_requires=["python-dateutil>=2.7.0"],
     license="Apache Software License 2.0",
     zip_safe=False,
     keywords=[


### PR DESCRIPTION
Putting python-dateutils directly in install_requires is simpler, allows code and a file to be deleted, and is more aligned with the guidance of the python packaging authority. See https://github.com/pypa/sampleproject/blob/master/setup.py#L143-L149.

I've also made it so that the testing server installs pystac before running the tests. Not only does this pull in the requirement listed in setup.py, it also checks that the package is installable, and tests the code as it would be run in production.