### PR TITLE
Updates for PySTAC 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
+## [v0.3.1] - 2019-11-04
+
+### Addeed
+
+- Add methods for removing single items and children from catalogs.
+- Add methods for removing objects from the ResolvedObjectCache.
+
+### Fixed
+
+- Fixed issue where cleared items and children were still in the root object cache.
+
+### Changed
+
+- Moved STAC version to 0.8.1
+- LabelItem reduced validation as there is some confusion on how segmentation classes
+
 ## [v0.3.0] - 2019-10-31
 
 Initial release.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,7 +2,7 @@ API Reference
 =============
 
 This API reference is auto-generated for the Python docstrings,
-and organized by the section of the `STAC Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.0>`_ they relate to, if related to a specific spec item.
+and organized by the section of the `STAC Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.1>`_ they relate to, if related to a specific spec item.
 
 Links
 -----
@@ -53,7 +53,7 @@ STACError
 Catalog Spec
 ------------
 
-These classes are representations of the `Catalog Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.0/catalog-spec>`_.
+These classes are representations of the `Catalog Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.1/catalog-spec>`_.
 
 Catalog
 ~~~~~~~
@@ -75,7 +75,7 @@ CatalogType
 Collection Spec
 ---------------
 
-These classes are representations of the `Collection Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.0/collection-spec>`_.
+These classes are representations of the `Collection Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.1/collection-spec>`_.
 
 Collection
 ~~~~~~~~~~
@@ -116,7 +116,7 @@ Provider
 Item Spec
 ---------
 
-These classes are representations of the `Item Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.0/item-spec>`_.
+These classes are representations of the `Item Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.1/item-spec>`_.
 
 Item
 ~~~~
@@ -143,7 +143,7 @@ ItemCollection
 EO Extension
 ------------
 
-These classes are representations of the `EO Extension Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.0/extensions/eo>`_.
+These classes are representations of the `EO Extension Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo>`_.
 
 EOItem
 ~~~~~~
@@ -172,7 +172,7 @@ Band
 Label Extension
 ---------------
 
-These classes are representations of the `Label Extension Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.0/extensions/label>`_.
+These classes are representations of the `Label Extension Spec <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/label>`_.
 
 LabelItem
 ~~~~~~~~~
@@ -220,7 +220,7 @@ LabelStatistics
 Single File STAC Extension
 --------------------------
 
-These classes are representations of the `Single File STAC Extension <https://github.com/radiantearth/stac-spec/tree/v0.8.0/extensions/single-file-stac>`_.
+These classes are representations of the `Single File STAC Extension <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/single-file-stac>`_.
 
 SingleFileSTAC
 ~~~~~~~~~~~~~~

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -26,7 +26,7 @@ Writing STACs
 
 While working with STACs in-memory don't require setting file paths, in order to save a STAC,
 you'll need to give each STAC object a ``self`` link that describes the location of where
-it should be saved to. Luckily, PySTAC makes it easy to create a STAC catalog with a `canonical layout <https://github.com/radiantearth/stac-spec/blob/v0.8.0/best-practices.md#catalog-layout>`_ and with the links that follow the `best practices <https://github.com/radiantearth/stac-spec/blob/v0.8.0/best-practices.md#use-of-links>`_. You simply call ``normalize_hrefs`` with the root directory of where the STAC will be saved, and then call ``save`` with the type of catalog (described in the :ref:`catalog types` section) that matches your use case.
+it should be saved to. Luckily, PySTAC makes it easy to create a STAC catalog with a `canonical layout <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#catalog-layout>`_ and with the links that follow the `best practices <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#use-of-links>`_. You simply call ``normalize_hrefs`` with the root directory of where the STAC will be saved, and then call ``save`` with the type of catalog (described in the :ref:`catalog types` section) that matches your use case.
 
 .. code-block:: python
 
@@ -85,7 +85,7 @@ manually by using ``set_self_href``:
 Catalog Types
 -------------
 
-The STAC `best practices document <https://github.com/radiantearth/stac-spec/blob/v0.8.0/best-practices.md>`_ lays out different catalog types, and how their links should be formatted. A brief description is below, but check out the document for the official take on these types:
+The STAC `best practices document <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md>`_ lays out different catalog types, and how their links should be formatted. A brief description is below, but check out the document for the official take on these types:
 
 Note that the catalog types do not dictate the asset HREF formats, only link formats. Asset HREFs in any catalog type can be relative or absolute; see the section on :ref:`rel vs abs asset` below.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ PySTAC Features
 * Allows in-memory manipulations of STAC catalogs.
 * Allows users to extend the IO of STAC metadata to provide support e.g. cloud providers.
 * Allows easy iteration over STAC objects. STAC objects are only read in when needed.
-* Allows users to easily write "absolute published", "relative published" and "self-contained" catalogs as `described in the best practices documentation <https://github.com/radiantearth/stac-spec/blob/v0.8.0/best-practices.md#use-of-links>`_.
+* Allows users to easily write "absolute published", "relative published" and "self-contained" catalogs as `described in the best practices documentation <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#use-of-links>`_.
 
 Acknowledgments
 ================

--- a/docs/tutorials/pystac-introduction.ipynb
+++ b/docs/tutorials/pystac-introduction.ipynb
@@ -337,7 +337,7 @@
      "data": {
       "text/plain": [
        "{'id': 'stac',\n",
-       " 'stac_version': '0.8.0',\n",
+       " 'stac_version': '0.8.1',\n",
        " 'description': 'A STAC of public datasets',\n",
        " 'links': [{'rel': 'child', 'href': './eo/catalog.json'},\n",
        "  {'rel': 'root', 'href': './catalog.json', 'type': 'application/json'}]}"
@@ -912,7 +912,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -42,6 +42,7 @@ def _stac_object_from_dict(d, href=None, root=None):
     Note: This is used internally in STAC_IO to deserialize STAC Objects.
     It is in the top level __init__ in order to avoid circular dependencies.
     """
+    extensions = d.get('stac_extensions', [])
     if 'type' in d:
         if d['type'] == 'FeatureCollection':
             # Dealing with an Item Collection
@@ -51,10 +52,11 @@ def _stac_object_from_dict(d, href=None, root=None):
                 return ItemCollection.from_dict(d, href=href, root=root)
         else:
             # Dealing with an Item
-            if any([k for k in d['properties'].keys() if k.startswith('eo:')]):
+            if 'eo' in extensions or \
+               any([k for k in d['properties'].keys() if k.startswith('eo:')]):
                 return EOItem.from_dict(d, href=href, root=root)
-            elif any(
-                [k for k in d['properties'].keys() if k.startswith('label:')]):
+            elif 'label' in extensions or \
+                 any([k for k in d['properties'].keys() if k.startswith('label:')]):
                 return LabelItem.from_dict(d, href=href, root=root)
             else:
                 return Item.from_dict(d, href=href, root=root)

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -16,7 +16,7 @@ class CatalogType:
     local computer, so all links need to be relative.
 
     See:
-        `The best practices documentation on self-contained catalogs <https://github.com/radiantearth/stac-spec/blob/v0.8.0/best-practices.md#self-contained-catalogs>`_
+        `The best practices documentation on self-contained catalogs <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#self-contained-catalogs>`_
     """ # noqa E501
 
     ABSOLUTE_PUBLISHED = 'ABSOLUTE_PUBLISHED'
@@ -25,7 +25,7 @@ class CatalogType:
     both in the links objects and in the asset hrefs.
 
     See:
-        `The best practices documentation on published catalogs <https://github.com/radiantearth/stac-spec/blob/v0.8.0-rc1/best-practices.md#published-catalogs>`_
+        `The best practices documentation on published catalogs <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#published-catalogs>`_
     """ # noqa E501
 
     RELATIVE_PUBLISHED = 'RELATIVE_PUBLISHED'
@@ -34,7 +34,7 @@ class CatalogType:
     but includes an absolute self link at the root catalog, to identify its online location.
 
     See:
-        `The best practices documentation on published catalogs <https://github.com/radiantearth/stac-spec/blob/v0.8.0-rc1/best-practices.md#published-catalogs>`_
+        `The best practices documentation on published catalogs <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#published-catalogs>`_
     """ # noqa E501
 
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -188,6 +188,27 @@ class Catalog(STACObject):
         self.links = [l for l in self.links if l.rel != 'child']
         return self
 
+    def remove_child(self, child_id):
+        """Removes an child from this catalog.
+
+        Args:
+            child_id (str): The ID of the child to remove.
+        """
+        new_links = []
+        root = self.get_root()
+        for l in self.links:
+            if l.rel != 'child':
+                new_links.append(l)
+            else:
+                l.resolve_stac_object(root=root)
+                if l.target.id != child_id:
+                    new_links.append(l)
+                else:
+                    child = l.target
+                    child.set_parent(None)
+                    child.set_root(None)
+        self.links = new_links
+
     def get_item(self, id, recursive=False):
         """Returns an item with a given ID.
 
@@ -226,9 +247,31 @@ class Catalog(STACObject):
             if link.is_resolved():
                 item = link.target
                 item.set_parent(None)
+                item.set_root(None)
 
         self.links = [l for l in self.links if l.rel != 'item']
         return self
+
+    def remove_item(self, item_id):
+        """Removes an item from this catalog.
+
+        Args:
+            item_id (str): The ID of the item to remove.
+        """
+        new_links = []
+        root = self.get_root()
+        for l in self.links:
+            if l.rel != 'item':
+                new_links.append(l)
+            else:
+                l.resolve_stac_object(root=root)
+                if l.target.id != item_id:
+                    new_links.append(l)
+                else:
+                    item = l.target
+                    item.set_parent(None)
+                    item.set_root(None)
+        self.links = new_links
 
     def get_all_items(self):
         """Get all items from this catalog and all subcatalogs. Will traverse

--- a/pystac/eo.py
+++ b/pystac/eo.py
@@ -368,7 +368,7 @@ class Band:
         name (str): The name of the band (e.g., "B01", "B02", "B1", "B5", "QA").
         common_name (str): The name commonly used to refer to the band to make it easier
             to search for bands across instruments. See the `list of accepted common names
-            <https://github.com/radiantearth/stac-spec/tree/v0.8.0/extensions/eo#common-band-names>`_.
+            <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
         description (str): Description to fully explain the band.
         gsd (float): Ground Sample Distance, the nominal distance between pixel
             centers available, in meters. Defaults to the EOItems' eo:gsd if not provided.
@@ -382,7 +382,7 @@ class Band:
         name (str): The name of the band (e.g., "B01", "B02", "B1", "B5", "QA").
         common_name (str): The name commonly used to refer to the band to make it easier
             to search for bands across instruments. See the `list of accepted common names
-            <https://github.com/radiantearth/stac-spec/tree/v0.8.0/extensions/eo#common-band-names>`_.
+            <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
         description (str): Description to fully explain the band.
         gsd (float): Ground Sample Distance, the nominal distance between pixel
             centers available, in meters. Defaults to the EOItems' eo:gsd if not provided.
@@ -418,7 +418,7 @@ class Band:
         """Gets the band range for a common band name.
 
         Args:
-            common_name (str): The common band name. Must be one of the `list of accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.0/extensions/eo#common-band-names>`_.
+            common_name (str): The common band name. Must be one of the `list of accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
 
         Returns:
             Tuple[float, float] or None: The band range for this name as (min, max), or
@@ -450,7 +450,7 @@ class Band:
         """Returns a description of the band for one with a common name.
 
         Args:
-            common_name (str): The common band name. Must be one of the `list of accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.0/extensions/eo#common-band-names>`_.
+            common_name (str): The common band name. Must be one of the `list of accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
 
         Returns:
             str or None: If a recognized common name, returns a description including the

--- a/pystac/eo.py
+++ b/pystac/eo.py
@@ -15,6 +15,7 @@ class EOItem(Item):
         bbox (List[float]):  Bounding Box of the asset represented by this item using
             either 2D or 3D geometries. The length of the array must be 2*n where n is the
             number of dimensions.
+        datetime (Datetime): Datetime associated with this item.
         properties (dict): A dictionary of additional metadata for the item.
         gsd (float): Ground Sample Distance at the sensor.
         platform (str): Unique name of the specific platform to which the instrument is attached.
@@ -49,6 +50,7 @@ class EOItem(Item):
         bbox (List[float]):  Bounding Box of the asset represented by this item using
             either 2D or 3D geometries. The length of the array is 2*n where n is the
             number of dimensions.
+        datetime (Datetime): Datetime associated with this item.
         properties (dict): A dictionary of additional metadata for the item.
         stac_extensions (List[str] or None): Optional list of extensions the Item implements.
         collection (Collection or None): Collection that this item is a part of.

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -25,6 +25,7 @@ class Item(STACObject):
         bbox (List[float]):  Bounding Box of the asset represented by this item using
             either 2D or 3D geometries. The length of the array must be 2*n where n is the
             number of dimensions.
+        datetime (Datetime): Datetime associated with this item.
         properties (dict): A dictionary of additional metadata for the item.
         stac_extensions (List[str]): Optional list of extensions the Item implements.
         href (str or None): Optional HREF for this item, which be set as the item's
@@ -40,6 +41,7 @@ class Item(STACObject):
         bbox (List[float]):  Bounding Box of the asset represented by this item using
             either 2D or 3D geometries. The length of the array is 2*n where n is the
             number of dimensions.
+        datetime (Datetime): Datetime associated with this item.
         properties (dict): A dictionary of additional metadata for the item.
         stac_extensions (List[str] or None): Optional list of extensions the Item implements.
         collection (Collection or None): Collection that this item is a part of.

--- a/pystac/label.py
+++ b/pystac/label.py
@@ -28,6 +28,7 @@ class LabelItem(Item):
         bbox (List[float]):  Bounding Box of the asset represented by this item using
             either 2D or 3D geometries. The length of the array must be 2*n where n is the
             number of dimensions.
+        datetime (Datetime): Datetime associated with this item.
         properties (dict): A dictionary of additional metadata for the item.
         label_desecription (str): A description of the label, how it was created,
             and what it is recommended for
@@ -51,6 +52,37 @@ class LabelItem(Item):
         href (str or None): Optional HREF for this item, which be set as the item's
             self link's HREF.
         collection (Collection): Optional Collection that this item is a part of.
+
+    Attributes:
+        id (str): Provider identifier. Unique within the STAC.
+        geometry (dict): Defines the full footprint of the asset represented by this item,
+            formatted according to `RFC 7946, section 3.1 (GeoJSON)
+            <https://tools.ietf.org/html/rfc7946>`_.
+        bbox (List[float]):  Bounding Box of the asset represented by this item using
+            either 2D or 3D geometries. The length of the array is 2*n where n is the
+            number of dimensions.
+        datetime (Datetime): Datetime associated with this item.
+        properties (dict): A dictionary of additional metadata for the item.
+        label_desecription (str): A description of the label, how it was created,
+            and what it is recommended for
+        label_type (str): An ENUM of either vector label type or raster label type (one
+            of :class:`~pystac.LabelType`).
+        label_properties (dict or None): These are the names of the property field(s) in each
+            Feature of the label asset's FeatureCollection that contains the classes
+            (keywords from label:classes if the property defines classes).
+            If labels are rasters, this should be None.
+        label_classes (List[LabelClass]): Optional, but reqiured if ussing categorical data.
+            A list of LabelClasses defining the list of possible class names for each
+            label:properties. (e.g., tree, building, car, hippo)
+        label_tasks (str): Tasks these labels apply to. Usually a subset of 'regression',
+            'classification', 'detection', or 'segmentation', but may be an arbitrary value.
+        label_methods: Methods used for labeling. Usually a subset of 'automated' or 'manual',
+            but may be an arbitrary value.
+        label_overviews (List[LabelOverview]): Optional list of LabelOverview classes
+            that store counts (for classification-type data) or summary statistics (for
+            continuous numerical/regression data).
+        stac_extensions (List[str] or None): Optional list of extensions the Item implements.
+        collection_id (str or None): The Collection ID that this item belongs to, if any.
 
     See:
         `Item fields in the label extension spec <https://github.com/radiantearth/stac-spec/tree/v0.8.0/extensions/label#item-fields>`_

--- a/pystac/label.py
+++ b/pystac/label.py
@@ -85,7 +85,7 @@ class LabelItem(Item):
         collection_id (str or None): The Collection ID that this item belongs to, if any.
 
     See:
-        `Item fields in the label extension spec <https://github.com/radiantearth/stac-spec/tree/v0.8.0/extensions/label#item-fields>`_
+        `Item fields in the label extension spec <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/label#item-fields>`_
     """ # noqa E501
 
     def __init__(self,

--- a/pystac/label.py
+++ b/pystac/label.py
@@ -110,19 +110,6 @@ class LabelItem(Item):
                             "{}; was {}".format(LabelType.ALL,
                                                 self.label_type))
 
-        if self.label_type == LabelType.VECTOR:
-            if self.label_properties is None:
-                raise STACError(
-                    'label_properties must be set for vector label type')
-
-        if self.label_tasks is not None:
-            for task in self.label_tasks:
-                if task in ['classification', 'detection', 'segmentation']:
-                    if self.label_classes is None:
-                        raise STACError('label_classes must be set '
-                                        'for task "{}"'.format(
-                                            self.label_tasks))
-
     def __repr__(self):
         return '<LabelItem id={}>'.format(self.id)
 

--- a/pystac/label.py
+++ b/pystac/label.py
@@ -274,6 +274,10 @@ class LabelItem(Item):
         props = item.properties
 
         label_properties = props.get('label:properties')
+        if label_properties is None:
+            # Allow for pre-0.8.1 non-pluralized form
+            label_properties = props.get('label:property')
+
         label_classes = props.get('label:classes')
         if label_classes is not None:
             label_classes = [
@@ -282,8 +286,17 @@ class LabelItem(Item):
         label_description = props['label:description']
         label_type = props['label:type']
         label_tasks = props.get('label:tasks')
+        if label_tasks is None:
+            # Allow for pre-0.8.1 non-pluralized form
+            label_tasks = props.get('label:task')
         label_methods = props.get('label:methods')
+        if label_methods is None:
+            # Allow for pre-0.8.1 non-pluralized form
+            label_methods = props.get('label:method')
         label_overviews = props.get('label:overviews')
+        if label_overviews is None:
+            # Allow for pre-0.8.1 non-pluralized form
+            label_overviews = props.get('label:overview')
         if label_overviews is not None:
             if type(label_overviews) is list:
                 label_overviews = [

--- a/pystac/resolved_object_cache.py
+++ b/pystac/resolved_object_cache.py
@@ -74,6 +74,22 @@ class ResolvedObjectCache:
         """
         self.ids_to_objects[obj.id] = obj
 
+    def remove(self, obj):
+        """Removes any cached object that matches the given object's id.
+
+        Args:
+            obj (STACObject): The object to remove
+        """
+        self.remove_by_id(obj.id)
+
+    def remove_by_id(self, obj_id):
+        """Removes any cached object that matches the given ID.
+
+        Args:
+            obj_id (str): The object ID to remove
+        """
+        self.ids_to_objects.pop(obj_id, None)
+
     def clone(self):
         """Clone this ResolvedObjectCache
 

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -262,7 +262,7 @@ class STACObject(LinkMixin, ABC):
         Note:
             When to include a self link is described in the `Use of Links section of the
             STAC best practices document
-            <https://github.com/radiantearth/stac-spec/blob/v0.8.0/best-practices.md#use-of-links>`_
+            <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#use-of-links>`_
         """
         self_href = self.get_self_href()
         if self_href is None:
@@ -342,7 +342,7 @@ class STACObject(LinkMixin, ABC):
             root_href (str): The absolute HREF that all links will be normalized against.
 
         See:
-            `STAC best practices document <https://github.com/radiantearth/stac-spec/blob/v0.8.0/best-practices.md#catalog-layout>`_ for the canonical layout of a STAC.
+            `STAC best practices document <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#catalog-layout>`_ for the canonical layout of a STAC.
         """ # noqa E501
         pass
 

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 """Library verison"""
 
 STAC_VERSION = '0.8.1'

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,5 +1,5 @@
 __version__ = '0.3.0'
 """Library verison"""
 
-STAC_VERSION = '0.8.0'
+STAC_VERSION = '0.8.1'
 """STAC version"""

--- a/tests/data-files/catalogs/test-case-1/catalog.json
+++ b/tests/data-files/catalogs/test-case-1/catalog.json
@@ -1,6 +1,6 @@
 {
     "id": "test",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "test catalog",
     "links": [
         {

--- a/tests/data-files/catalogs/test-case-1/country-1/area-1-1/area-1-1-imagery/area-1-1-imagery.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/area-1-1/area-1-1-imagery/area-1-1-imagery.json
@@ -1,6 +1,6 @@
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "area-1-1-imagery",
     "properties": {
         "datetime": "2019-10-04 18:55:37Z"

--- a/tests/data-files/catalogs/test-case-1/country-1/area-1-1/area-1-1-labels/area-1-1-labels.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/area-1-1/area-1-1-labels/area-1-1-labels.json
@@ -1,6 +1,6 @@
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "area-1-1-labels",
     "properties": {
         "datetime": "2019-10-04 18:55:37Z",

--- a/tests/data-files/catalogs/test-case-1/country-1/area-1-1/collection.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/area-1-1/collection.json
@@ -1,6 +1,6 @@
 {
     "id": "area-1-1",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "test collection country-1",
     "links": [
         {

--- a/tests/data-files/catalogs/test-case-1/country-1/area-1-2/area-1-2-imagery/area-1-2-imagery.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/area-1-2/area-1-2-imagery/area-1-2-imagery.json
@@ -1,6 +1,6 @@
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "area-1-2-imagery",
     "properties": {
         "datetime": "2019-10-04 18:55:37Z"

--- a/tests/data-files/catalogs/test-case-1/country-1/area-1-2/area-1-2-labels/area-1-2-labels.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/area-1-2/area-1-2-labels/area-1-2-labels.json
@@ -1,6 +1,6 @@
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "area-1-2-labels",
     "properties": {
         "datetime": "2019-10-04 18:55:37Z",

--- a/tests/data-files/catalogs/test-case-1/country-1/area-1-2/collection.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/area-1-2/collection.json
@@ -1,6 +1,6 @@
 {
     "id": "area-1-2",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "test collection country-1",
     "links": [
         {

--- a/tests/data-files/catalogs/test-case-1/country-1/catalog.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/catalog.json
@@ -1,6 +1,6 @@
 {
     "id": "country-1",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "test catalog country-1",
     "links": [
         {

--- a/tests/data-files/catalogs/test-case-1/country-2/area-2-1/area-2-1-imagery/area-2-1-imagery.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/area-2-1/area-2-1-imagery/area-2-1-imagery.json
@@ -1,6 +1,6 @@
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "area-2-1-imagery",
     "properties": {
         "datetime": "2019-10-04 18:55:37Z"

--- a/tests/data-files/catalogs/test-case-1/country-2/area-2-1/area-2-1-labels/area-2-1-labels.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/area-2-1/area-2-1-labels/area-2-1-labels.json
@@ -1,6 +1,6 @@
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "area-2-1-labels",
     "properties": {
         "datetime": "2019-10-04 18:55:37Z",

--- a/tests/data-files/catalogs/test-case-1/country-2/area-2-1/collection.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/area-2-1/collection.json
@@ -1,6 +1,6 @@
 {
     "id": "area-2-1",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "test collection country-2",
     "links": [
         {

--- a/tests/data-files/catalogs/test-case-1/country-2/area-2-2/area-2-2-imagery/area-2-2-imagery.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/area-2-2/area-2-2-imagery/area-2-2-imagery.json
@@ -1,6 +1,6 @@
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "area-2-2-imagery",
     "properties": {
         "datetime": "2019-10-04 18:55:37Z"

--- a/tests/data-files/catalogs/test-case-1/country-2/area-2-2/area-2-2-labels/area-2-2-labels.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/area-2-2/area-2-2-labels/area-2-2-labels.json
@@ -1,6 +1,6 @@
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "area-2-2-labels",
     "properties": {
         "datetime": "2019-10-04 18:55:37Z",

--- a/tests/data-files/catalogs/test-case-1/country-2/area-2-2/collection.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/area-2-2/collection.json
@@ -1,6 +1,6 @@
 {
     "id": "area-2-2",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "test collection country-2",
     "links": [
         {

--- a/tests/data-files/catalogs/test-case-1/country-2/catalog.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/catalog.json
@@ -1,6 +1,6 @@
 {
     "id": "country-2",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "test catalog country-2",
     "links": [
         {

--- a/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/5b922d42-9a77-4f79-a672-86096f7f849e/cf73ec1a-d790-4b59-b077-e101738571ed/cf73ec1a-d790-4b59-b077-e101738571ed.json
+++ b/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/5b922d42-9a77-4f79-a672-86096f7f849e/cf73ec1a-d790-4b59-b077-e101738571ed/cf73ec1a-d790-4b59-b077-e101738571ed.json
@@ -1,6 +1,6 @@
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "cf73ec1a-d790-4b59-b077-e101738571ed",
     "properties": {
         "label:description": "Labels in layer",

--- a/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/5b922d42-9a77-4f79-a672-86096f7f849e/collection.json
+++ b/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/5b922d42-9a77-4f79-a672-86096f7f849e/collection.json
@@ -1,6 +1,6 @@
 {
     "id": "5b922d42-9a77-4f79-a672-86096f7f849e",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "Label collection in layer 1a8c1632-fa91-4a62-b33e-3a87c2ebdf16",
     "links": [
         {

--- a/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/collection.json
+++ b/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/collection.json
@@ -1,6 +1,6 @@
 {
     "id": "1a8c1632-fa91-4a62-b33e-3a87c2ebdf16",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "Project layer collection",
     "links": [
         {

--- a/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/f433578c-f879-414d-8101-83142a0a13c3/collection.json
+++ b/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/f433578c-f879-414d-8101-83142a0a13c3/collection.json
@@ -1,6 +1,6 @@
 {
     "id": "f433578c-f879-414d-8101-83142a0a13c3",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "Scene collection in layer 1a8c1632-fa91-4a62-b33e-3a87c2ebdf16",
     "links": [
         {

--- a/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/f433578c-f879-414d-8101-83142a0a13c3/d43bead8-e3f8-4c51-95d6-e24e750a402b/d43bead8-e3f8-4c51-95d6-e24e750a402b.json
+++ b/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/f433578c-f879-414d-8101-83142a0a13c3/d43bead8-e3f8-4c51-95d6-e24e750a402b/d43bead8-e3f8-4c51-95d6-e24e750a402b.json
@@ -1,6 +1,6 @@
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "d43bead8-e3f8-4c51-95d6-e24e750a402b",
     "properties": {
         "datetime": "2019-08-07 20:37:10Z"

--- a/tests/data-files/catalogs/test-case-2/catalog.json
+++ b/tests/data-files/catalogs/test-case-2/catalog.json
@@ -1,6 +1,6 @@
 {
     "id": "01749366-9e25-4b42-a4d1-5aae9f8c9eec",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "description": "Exported from Raster Foundry 2019-10-04 15:55:13.759",
     "links": [
         {

--- a/tests/data-files/eo/eo-landsat-example-INVALID.json
+++ b/tests/data-files/eo/eo-landsat-example-INVALID.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "stac_extensions": [
       "eo",
       "https://example.com/stac/landsat-extension/1.0/schema.json"

--- a/tests/data-files/eo/eo-landsat-example.json
+++ b/tests/data-files/eo/eo-landsat-example.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "stac_extensions": [
       "eo",
       "https://example.com/stac/landsat-extension/1.0/schema.json"

--- a/tests/data-files/itemcollections/example-search.json
+++ b/tests/data-files/itemcollections/example-search.json
@@ -4,7 +4,7 @@
         {
             "type": "Feature",
             "id": "LC80370332018039LGN00",
-            "stac_version": "0.8.0",
+            "stac_version": "0.8.1",
             "collection": "landsat-8-l1",
             "bbox": [
                 -112.21054,
@@ -172,7 +172,7 @@
         {
             "type": "Feature",
             "id": "LC80340332018034LGN00",
-            "stac_version": "0.8.0",
+            "stac_version": "0.8.1",
             "collection": "landsat-8-l1",
             "bbox": [
                 -107.6044,
@@ -349,7 +349,7 @@
                 "usgs"
             ],
             "version": "0.1.0",
-            "stac_version": "0.8.0",
+            "stac_version": "0.8.1",
             "extent": {
                 "spatial": {
                     "bbox": [

--- a/tests/data-files/itemcollections/sample-item-collection.json
+++ b/tests/data-files/itemcollections/sample-item-collection.json
@@ -2,7 +2,7 @@
     "type": "FeatureCollection",
     "features": [
       {
-        "stac_version": "0.8.0",
+        "stac_version": "0.8.1",
         "stac_extensions": [],
         "type": "Feature",
         "id": "CS3-20160503_132131_05",
@@ -62,7 +62,7 @@
           },
           {
             "rel": "collection",
-            "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.0/collection-spec/examples/sentinel2.json"
+            "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/examples/sentinel2.json"
           }
         ],
         "assets": {

--- a/tests/data-files/label/label-example-1.json
+++ b/tests/data-files/label/label-example-1.json
@@ -1,7 +1,7 @@
 
 {
     "type": "Feature",
-    "stac_version": "0.8.0",
+    "stac_version": "0.8.1",
     "id": "label-example-1-label-item",
     "properties": {
         "datetime": "2019-10-04 18:55:37Z",

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -66,6 +66,44 @@ class CatalogTest(unittest.TestCase):
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].properties['key'], 'two')
 
+        subcat.remove_item('test-item')
+        item = Item(id='test-item',
+                    geometry=RANDOM_GEOM,
+                    bbox=RANDOM_BBOX,
+                    datetime=datetime.utcnow(),
+                    properties={ 'key': 'three' })
+        subcat.add_item(item)
+
+        items = list(catalog.get_all_items())
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].properties['key'], 'three')
+
+    def test_clear_children_removes_from_cache(self):
+        catalog = Catalog(id='test', description='test')
+        subcat = Catalog(id='subcat', description='test')
+        catalog.add_child(subcat)
+
+        children = list(catalog.get_children())
+        self.assertEqual(len(children), 1)
+        self.assertEqual(children[0].description, 'test')
+
+        catalog.clear_children()
+        subcat = Catalog(id='subcat', description='test2')
+        catalog.add_child(subcat)
+
+        children = list(catalog.get_children())
+        self.assertEqual(len(children), 1)
+        self.assertEqual(children[0].description, 'test2')
+
+        catalog.remove_child('subcat')
+        subcat = Catalog(id='subcat', description='test3')
+        catalog.add_child(subcat)
+
+        children = list(catalog.get_children())
+        self.assertEqual(len(children), 1)
+        self.assertEqual(children[0].description, 'test3')
+
+
     def test_map_items(self):
         def item_mapper(item):
             item.properties['ITEM_MAPPER'] = 'YEP'

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -47,7 +47,7 @@ class CatalogTest(unittest.TestCase):
                     geometry=RANDOM_GEOM,
                     bbox=RANDOM_BBOX,
                     datetime=datetime.utcnow(),
-                    properties={ 'key': 'one' })
+                    properties={'key': 'one'})
         subcat.add_item(item)
 
         items = list(catalog.get_all_items())
@@ -59,7 +59,7 @@ class CatalogTest(unittest.TestCase):
                     geometry=RANDOM_GEOM,
                     bbox=RANDOM_BBOX,
                     datetime=datetime.utcnow(),
-                    properties={ 'key': 'two' })
+                    properties={'key': 'two'})
         subcat.add_item(item)
 
         items = list(catalog.get_all_items())
@@ -71,7 +71,7 @@ class CatalogTest(unittest.TestCase):
                     geometry=RANDOM_GEOM,
                     bbox=RANDOM_BBOX,
                     datetime=datetime.utcnow(),
-                    properties={ 'key': 'three' })
+                    properties={'key': 'three'})
         subcat.add_item(item)
 
         items = list(catalog.get_all_items())
@@ -102,7 +102,6 @@ class CatalogTest(unittest.TestCase):
         children = list(catalog.get_children())
         self.assertEqual(len(children), 1)
         self.assertEqual(children[0].description, 'test3')
-
 
     def test_map_items(self):
         def item_mapper(item):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -39,6 +39,33 @@ class CatalogTest(unittest.TestCase):
 
         self.assertEqual(len(list(zanzibar.get_items())), 2)
 
+    def test_clear_items_removes_from_cache(self):
+        catalog = Catalog(id='test', description='test')
+        subcat = Catalog(id='subcat', description='test')
+        catalog.add_child(subcat)
+        item = Item(id='test-item',
+                    geometry=RANDOM_GEOM,
+                    bbox=RANDOM_BBOX,
+                    datetime=datetime.utcnow(),
+                    properties={ 'key': 'one' })
+        subcat.add_item(item)
+
+        items = list(catalog.get_all_items())
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].properties['key'], 'one')
+
+        subcat.clear_items()
+        item = Item(id='test-item',
+                    geometry=RANDOM_GEOM,
+                    bbox=RANDOM_BBOX,
+                    datetime=datetime.utcnow(),
+                    properties={ 'key': 'two' })
+        subcat.add_item(item)
+
+        items = list(catalog.get_all_items())
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].properties['key'], 'two')
+
     def test_map_items(self):
         def item_mapper(item):
             item.properties['ITEM_MAPPER'] = 'YEP'
@@ -282,6 +309,7 @@ class CatalogTest(unittest.TestCase):
             for root, catalogs, items in cat.walk():
                 for l in root.links:
                     if l.rel != 'self':
+                        # print(l.rel)
                         self.assertTrue(l.link_type == LinkType.RELATIVE)
                         self.assertFalse(is_absolute_href(l.get_href()))
                 for i in items:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -2,8 +2,8 @@ import unittest
 from tempfile import TemporaryDirectory
 from datetime import datetime
 
-from pystac import (Collection, Item, Extent, SpatialExtent,
-                    TemporalExtent, CatalogType, EOItem, Band)
+from pystac import (Collection, Item, Extent, SpatialExtent, TemporalExtent,
+                    CatalogType, EOItem, Band)
 from tests.utils import (RANDOM_GEOM, RANDOM_BBOX)
 
 
@@ -22,15 +22,15 @@ class CollectionTest(unittest.TestCase):
                      geometry=RANDOM_GEOM,
                      bbox=RANDOM_BBOX,
                      datetime=datetime.utcnow(),
-                     properties={ 'key': 'one' },
+                     properties={'key': 'one'},
                      stac_extensions=['eo'])
 
         item2 = Item(id='test-item-2',
-                    geometry=RANDOM_GEOM,
-                    bbox=RANDOM_BBOX,
-                    datetime=datetime.utcnow(),
-                    properties={ 'key': 'two' },
-                    stac_extensions=['eo'])
+                     geometry=RANDOM_GEOM,
+                     bbox=RANDOM_BBOX,
+                     datetime=datetime.utcnow(),
+                     properties={'key': 'two'},
+                     stac_extensions=['eo'])
 
         wv3_bands = [
             Band(name='Coastal',
@@ -62,12 +62,15 @@ class CollectionTest(unittest.TestCase):
         spatial_extent = SpatialExtent(bboxes=[RANDOM_BBOX])
         temporal_extent = TemporalExtent(intervals=[[item1.datetime, None]])
 
-        collection_extent = Extent(spatial=spatial_extent, temporal=temporal_extent)
+        collection_extent = Extent(spatial=spatial_extent,
+                                   temporal=temporal_extent)
 
-        common_properties = { 'eo:bands': [b.to_dict() for b in wv3_bands],
-                              'eo:gsd': 0.3,
-                              'eo:platform': 'Maxar',
-                              'eo:instrument': 'WorldView3' }
+        common_properties = {
+            'eo:bands': [b.to_dict() for b in wv3_bands],
+            'eo:gsd': 0.3,
+            'eo:platform': 'Maxar',
+            'eo:instrument': 'WorldView3'
+        }
 
         collection = Collection(id='test',
                                 description='test',
@@ -81,7 +84,8 @@ class CollectionTest(unittest.TestCase):
             collection.normalize_hrefs(tmp_dir)
             collection.save(catalog_type=CatalogType.SELF_CONTAINED)
 
-            read_col = Collection.from_file('{}/collection.json'.format(tmp_dir))
+            read_col = Collection.from_file(
+                '{}/collection.json'.format(tmp_dir))
             items = list(read_col.get_all_items())
 
             self.assertEqual(len(items), 2)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,7 +1,10 @@
 import unittest
+from tempfile import TemporaryDirectory
+from datetime import datetime
 
-from pystac import SpatialExtent
-from tests.utils import RANDOM_GEOM
+from pystac import (Collection, Item, Extent, SpatialExtent,
+                    TemporalExtent, CatalogType, EOItem, Band)
+from tests.utils import (RANDOM_GEOM, RANDOM_BBOX)
 
 
 class CollectionTest(unittest.TestCase):
@@ -13,3 +16,74 @@ class CollectionTest(unittest.TestCase):
         self.assertEqual(len(bbox), 4)
         for x in bbox:
             self.assertTrue(type(x) is float)
+
+    def test_eo_items_are_heritable(self):
+        item1 = Item(id='test-item-1',
+                     geometry=RANDOM_GEOM,
+                     bbox=RANDOM_BBOX,
+                     datetime=datetime.utcnow(),
+                     properties={ 'key': 'one' },
+                     stac_extensions=['eo'])
+
+        item2 = Item(id='test-item-2',
+                    geometry=RANDOM_GEOM,
+                    bbox=RANDOM_BBOX,
+                    datetime=datetime.utcnow(),
+                    properties={ 'key': 'two' },
+                    stac_extensions=['eo'])
+
+        wv3_bands = [
+            Band(name='Coastal',
+                 description='Coastal: 400 - 450 nm',
+                 common_name='coastal'),
+            Band(name='Blue',
+                 description='Blue: 450 - 510 nm',
+                 common_name='blue'),
+            Band(name='Green',
+                 description='Green: 510 - 580 nm',
+                 common_name='green'),
+            Band(name='Yellow',
+                 description='Yellow: 585 - 625 nm',
+                 common_name='yellow'),
+            Band(name='Red',
+                 description='Red: 630 - 690 nm',
+                 common_name='red'),
+            Band(name='Red Edge',
+                 description='Red Edge: 705 - 745 nm',
+                 common_name='rededge'),
+            Band(name='Near-IR1',
+                 description='Near-IR1: 770 - 895 nm',
+                 common_name='nir08'),
+            Band(name='Near-IR2',
+                 description='Near-IR2: 860 - 1040 nm',
+                 common_name='nir09')
+        ]
+
+        spatial_extent = SpatialExtent(bboxes=[RANDOM_BBOX])
+        temporal_extent = TemporalExtent(intervals=[[item1.datetime, None]])
+
+        collection_extent = Extent(spatial=spatial_extent, temporal=temporal_extent)
+
+        common_properties = { 'eo:bands': [b.to_dict() for b in wv3_bands],
+                              'eo:gsd': 0.3,
+                              'eo:platform': 'Maxar',
+                              'eo:instrument': 'WorldView3' }
+
+        collection = Collection(id='test',
+                                description='test',
+                                extent=collection_extent,
+                                properties=common_properties,
+                                license='CC-BY-SA-4.0')
+
+        collection.add_items([item1, item2])
+
+        with TemporaryDirectory() as tmp_dir:
+            collection.normalize_hrefs(tmp_dir)
+            collection.save(catalog_type=CatalogType.SELF_CONTAINED)
+
+            read_col = Collection.from_file('{}/collection.json'.format(tmp_dir))
+            items = list(read_col.get_all_items())
+
+            self.assertEqual(len(items), 2)
+            self.assertIsInstance(items[0], EOItem)
+            self.assertIsInstance(items[1], EOItem)

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from tempfile import TemporaryDirectory
 
-from pystac import (Catalog, CatalogType, LabelItem)
+from pystac import (Catalog, CatalogType, LabelItem, STAC_IO)
 from tests.utils import (SchemaValidator, TestCases, test_to_from_dict)
 
 
@@ -23,6 +23,21 @@ class LabelItemTest(unittest.TestCase):
         label_example_1 = LabelItem.from_file(self.label_example_1_uri)
 
         self.assertEqual(len(label_example_1.label_overviews[0].counts), 2)
+
+    def test_from_file_pre_081(self):
+        d = STAC_IO.read_json(self.label_example_1_uri)
+
+        d['properties']['label:property'] = d['properties']['label:properties']
+        d['properties'].pop('label:properties')
+        d['properties']['label:overview'] = d['properties']['label:overviews']
+        d['properties'].pop('label:overviews')
+        d['properties']['label:method'] = d['properties']['label:methods']
+        d['properties'].pop('label:methods')
+        d['properties']['label:task'] = d['properties']['label:tasks']
+        d['properties'].pop('label:tasks')
+        label_example_1 = LabelItem.from_dict(d)
+
+        self.assertEqual(len(label_example_1.label_tasks), 1)
 
     def test_get_sources(self):
         cat = TestCases.test_case_1()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -123,9 +123,8 @@ class SchemaValidator:
     # Temporarily set to point to a fork if stac-spec with updated
     # schemas for Label and EO
     # Pending this issue being resolved: https://github.com/radiantearth/stac-spec/issues/618
-    SCHEMA_BASE_URI = (
-        'https://raw.githubusercontent.com/lossyrob/stac-spec/'
-        '0.8.1/refactor-extension-schemas')
+    SCHEMA_BASE_URI = ('https://raw.githubusercontent.com/lossyrob/stac-spec/'
+                       '0.8.1/refactor-extension-schemas')
 
     schemas = {
         Catalog: 'catalog-spec/json-schema/catalog.json',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -124,8 +124,8 @@ class SchemaValidator:
     # schemas for Label and EO
     # Pending this issue being resolved: https://github.com/radiantearth/stac-spec/issues/618
     SCHEMA_BASE_URI = (
-        'https://raw.githubusercontent.com/simonkassel/stac-spec/'
-        'sk/refactor-extension-schemas')
+        'https://raw.githubusercontent.com/lossyrob/stac-spec/'
+        '0.8.1/refactor-extension-schemas')
 
     schemas = {
         Catalog: 'catalog-spec/json-schema/catalog.json',


### PR DESCRIPTION
Changes in this PR:

- Removed some of the validation logic around LabelItem, which can feel restrictive in the case where GeoJSON labels have an implicit class without a Feature property that states the class (e.g. SpaceNet 5 doesn't have a 'roads' class in a label property; it's known that the GeoJSON contains roads). I think some tweaking of the requirements of the label extension spec has to be done.
- Made some backwards compatibility changes for 0.8.0 -> 0.8.1 due to https://github.com/radiantearth/stac-spec/pull/597 to reduce user pain.
- Move STAC_VERSION to 0.8.1, all links and references now point to that tag.
- Check `stac_extensions` when determining what class to deserialize. This was necessary for an instance where the `Item` properties didn't have any `eo:` properties, but the collection held all `eo:` properties - these should still deserialize to `EOItem`.
- Fixed an issue where cleared items and children were still being held in the ResolvedObjectCache of a Catalog.