### PR TITLE
Be consistent about owner vs item for owning item

### DIFF
--- a/pystac/eo.py
+++ b/pystac/eo.py
@@ -262,7 +262,7 @@ class EOAsset(Asset):
         properties (dict): Optional, additional properties for this asset. This is used by
             extensions as a way to serialize and deserialize properties on asset
             object JSON.
-        item (Item or None): The Item this asset belongs to.
+        owner (Item or None): The Item this asset belongs to.
     """
     def __init__(self,
                  href,

--- a/pystac/eo.py
+++ b/pystac/eo.py
@@ -356,9 +356,9 @@ class EOAsset(Asset):
             of asset.
         """
 
-        if not self.item:
+        if not self.owner:
             raise STACError('Asset is currently not associated with an item.')
-        return [self.item.bands[i] for i in self.bands]
+        return [self.owner.bands[i] for i in self.bands]
 
 
 class Band:

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -321,7 +321,7 @@ class Asset:
         properties (dict): Optional, additional properties for this asset. This is used by
             extensions as a way to serialize and deserialize properties on asset
             object JSON.
-        item (Item or None): The Item this asset belongs to.
+        owner (Item or None): The Item this asset belongs to.
     """
     def __init__(self, href, title=None, media_type=None, properties=None):
         self.href = href

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -330,7 +330,7 @@ class Asset:
         self.properties = properties
 
         # The Item which owns this Asset.
-        self.item = None
+        self.owner = None
 
     def set_owner(self, item):
         """Sets the owning item of this Asset.
@@ -340,7 +340,7 @@ class Asset:
         Args:
             item (Item): The Item that owns this asset.
         """
-        self.item = item
+        self.owner = item
 
     def get_absolute_href(self):
         """Gets the absolute href for this asset, if possible.
@@ -354,7 +354,7 @@ class Asset:
             cannot be determined.
         """
         if not is_absolute_href(self.href):
-            if self.item is not None:
+            if self.owner is not None:
                 return make_absolute_href(self.href,
                                           self.owner.get_self_href())
 

--- a/tests/test_eo.py
+++ b/tests/test_eo.py
@@ -67,7 +67,7 @@ class EOItemTest(unittest.TestCase):
         a = Asset('/asset_dir/asset.json')
         eoa = EOAsset('/asset_dir/eo_asset.json', bands=[0, 1])
         for asset in (a, eoa):
-            self.assertIsNone(asset.item)
+            self.assertIsNone(asset.owner)
         eoi_c.add_asset('new_asset', a)
         eoi_c.add_asset('new_eo_asset', eoa)
         self.assertEqual(len(eoi_c.assets.items()),
@@ -75,7 +75,7 @@ class EOItemTest(unittest.TestCase):
         self.assertEqual(a, eoi_c.assets['new_asset'])
         self.assertEqual(eoa, eoi_c.assets['new_eo_asset'])
         for asset in (a, eoa):
-            self.assertEqual(asset.item, eoi_c)
+            self.assertEqual(asset.owner, eoi_c)
 
     def test_add_eo_fields_to_dict(self):
         d = {}

--- a/tests/test_eo.py
+++ b/tests/test_eo.py
@@ -154,7 +154,7 @@ class EOAssetTest(unittest.TestCase):
         eoi = EOItem.from_file(self.EO_ITEM_URI)
         eoa = EOAsset.from_dict(self.EO_ASSET_DICT)
         eoi.add_asset('test-asset', eoa)
-        self.assertEqual(eoa.item, eoi)
+        self.assertEqual(eoa.owner, eoi)
         bd = {
             "name": "B1",
             "common_name": "coastal",

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,7 +1,7 @@
 import unittest
 import json
 
-from pystac import Item
+from pystac import Asset, Item
 from tests.utils import (TestCases, test_to_from_dict)
 
 
@@ -24,3 +24,15 @@ class ItemTest(unittest.TestCase):
         self.assertEqual(item.assets['analytic'].properties['product'],
                          'http://cool-sat.com/catalog/products/analytic.json')
         self.assertIsNone(item.assets['thumbnail'].properties)
+
+    def test_asset_absolute_href(self):
+        m = TestCases.get_path(
+            'data-files/itemcollections/sample-item-collection.json')
+        with open(m) as f:
+            item_dict = json.load(f)['features'][0]
+        item = Item.from_dict(item_dict)
+        rel_asset = Asset('./data.geojson')
+        rel_asset.set_owner(item)
+        expected_href = 'http://stacspec.org/data.geojson'
+        actual_href = rel_asset.get_absolute_href()
+        self.assertEqual(expected_href, actual_href)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -33,6 +33,6 @@ class ItemTest(unittest.TestCase):
         item = Item.from_dict(item_dict)
         rel_asset = Asset('./data.geojson')
         rel_asset.set_owner(item)
-        expected_href = 'http://stacspec.org/data.geojson'
+        expected_href = 'http://cool-sat.com/catalog/CS3-20160503_132130_04/data.geojson'
         actual_href = rel_asset.get_absolute_href()
         self.assertEqual(expected_href, actual_href)


### PR DESCRIPTION
Overview
----

This PR makes the API around setting an owning item more obvious, and also refers to an actually existing property in `get_absolute_href` for `Asset`s.

Testing
-----

- tests