### PR TITLE
Fix link to STAC's site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://readthedocs.org/projects/pystac/badge/?version=latest)](https://pystac.readthedocs.io/en/latest/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-PySTAC is a library for working with [SpatialTemporal Asset Catalog](https://stacgeo.org) in Python 3.
+PySTAC is a library for working with [SpatialTemporal Asset Catalog](https://stacspec.org) in Python 3.
 
 ## Installation
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,14 +37,14 @@ class UtilsTest(unittest.TestCase):
             ('./item.json', '/a/b/c/catalog.json', '/a/b/c/item.json'),
             ('./z/item.json', '/a/b/c/catalog.json', '/a/b/c/z/item.json'),
             ('../item.json', '/a/b/c/catalog.json', '/a/b/item.json'),
-            ('item.json', 'https://stacgeo.org/a/b/c/catalog.json',
-             'https://stacgeo.org/a/b/c/item.json'),
-            ('./item.json', 'https://stacgeo.org/a/b/c/catalog.json',
-             'https://stacgeo.org/a/b/c/item.json'),
-            ('./z/item.json', 'https://stacgeo.org/a/b/c/catalog.json',
-             'https://stacgeo.org/a/b/c/z/item.json'),
-            ('../item.json', 'https://stacgeo.org/a/b/c/catalog.json',
-             'https://stacgeo.org/a/b/item.json')
+            ('item.json', 'https://stacspec.org/a/b/c/catalog.json',
+             'https://stacspec.org/a/b/c/item.json'),
+            ('./item.json', 'https://stacspec.org/a/b/c/catalog.json',
+             'https://stacspec.org/a/b/c/item.json'),
+            ('./z/item.json', 'https://stacspec.org/a/b/c/catalog.json',
+             'https://stacspec.org/a/b/c/z/item.json'),
+            ('../item.json', 'https://stacspec.org/a/b/c/catalog.json',
+             'https://stacspec.org/a/b/item.json')
         ]
 
         for source_href, start_href, expected in test_cases:
@@ -55,7 +55,7 @@ class UtilsTest(unittest.TestCase):
         # Test cases of (href, expected)
         test_cases = [('item.json', False), ('./item.json', False),
                       ('../item.json', False), ('/item.json', True),
-                      ('http://stacgeo.org/item.json', True)]
+                      ('http://stacspec.org/item.json', True)]
 
         for href, expected in test_cases:
             actual = is_absolute_href(href)


### PR DESCRIPTION
The link to STAC's site was wrong and pointing to a non-existing address.

https://stacgeo.org => https://stacspec.org

PS: Also changed test case URLs just to keep the consistency.