### PR TITLE
Updated MediaTypes to reflect correct GeoTIFF and COG names

### DIFF
--- a/pystac/media_type.py
+++ b/pystac/media_type.py
@@ -2,8 +2,8 @@ class MediaType:
     """A list of common media types that can be used in STAC Asset and Link metadata.
     """
     TIFF = 'image/tiff'
-    GEOTIFF = 'image/vnd.stac.geotiff'
-    COG = 'image/vnd.stac.geotiff; cloud-optimized=true'
+    GEOTIFF = 'image/tiff; application=geotiff'
+    COG = 'image/tiff; application=geotiff; profile=cloud-optimized'
     JPEG2000 = 'image/jp2'
     PNG = 'image/png'
     JPEG = 'image/jpeg'


### PR DESCRIPTION
Replace the `vnd.` media types for GeoTIFF and COGs with the ones contained in [the media types section of the stac spec](https://github.com/radiantearth/stac-spec/blob/v0.8.1/item-spec/item-spec.md#media-types).