### PR TITLE
Remove 3.4 build as it conflicts with dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"


### PR DESCRIPTION
Installing the dev dependencies on travis produces the message:

> PyYAML requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.8

Remove the 3.4 build as it's not strictly necessary as a quick fix.