### PR TITLE
Fix utils to work with windows paths.

### DIFF
--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -1,5 +1,41 @@
 import os
-from urllib.parse import urlparse
+import posixpath
+from urllib.parse import (urlparse, ParseResult as URLParseResult)
+
+# Allow for modifying the path library for testability
+# (i.e. testing Windows path manipulation on non-Windows systems)
+_pathlib = os.path
+
+
+def _urlparse(href):
+    """Version of URL parse that takes into account windows paths.
+
+    A windows absolute path will be parsed with a scheme from urllib.parse.urlparse.
+    This method will take this into account.
+    """
+    parsed = urlparse(href)
+    if parsed.scheme != '' and href.lower().startswith('{}:\\'.format(
+            parsed.scheme)):
+        return URLParseResult(scheme='',
+                              netloc='',
+                              path='{}:{}'.format(parsed.scheme, parsed.path),
+                              params=parsed.params,
+                              query=parsed.query,
+                              fragment=parsed.fragment)
+    else:
+        return parsed
+
+
+def _join(is_path, *args):
+    """Version of os.path.join that takes into account whether or not we are working
+    with a URL.
+
+    A windows system shouldn't use os.path.join if we're working with a URL.
+    """
+    if is_path:
+        return _pathlib.join(*args)
+    else:
+        return posixpath.join(*args)
 
 
 def make_relative_href(source_href, start_href, start_is_dir=False):
@@ -16,19 +52,24 @@ def make_relative_href(source_href, start_href, start_is_dir=False):
         str: The relative HREF. If the source_href and start_href do not share a common
         parent, then source_href will be returned unchanged.
     """
-    parsed_source = urlparse(source_href)
-    parsed_start = urlparse(start_href)
+
+    parsed_source = _urlparse(source_href)
+    parsed_start = _urlparse(start_href)
     if not (parsed_source.scheme == parsed_start.scheme
             and parsed_source.netloc == parsed_start.netloc):
         return source_href
 
+    is_path = parsed_start.scheme == ''
+
     if start_is_dir:
         start_dir = parsed_start.path
     else:
-        start_dir = os.path.dirname(parsed_start.path)
-    relpath = os.path.relpath(parsed_source.path, start_dir)
+        start_dir = _pathlib.dirname(parsed_start.path)
+    relpath = _pathlib.relpath(parsed_source.path, start_dir)
+    if not is_path:
+        relpath = relpath.replace('\\', '/')
     if not relpath.startswith('.'):
-        relpath = './{}'.format(relpath)
+        relpath = _join(is_path, '.', relpath)
 
     return relpath
 
@@ -52,17 +93,21 @@ def make_absolute_href(source_href, start_href=None, start_is_dir=False):
         start_href = os.getcwd()
         start_is_dir = True
 
-    parsed_source = urlparse(source_href)
+    parsed_source = _urlparse(source_href)
     if parsed_source.scheme == '':
-        if not os.path.isabs(parsed_source.path):
-            parsed_start = urlparse(start_href)
+        if not _pathlib.isabs(parsed_source.path):
+            parsed_start = _urlparse(start_href)
+            is_path = parsed_start.scheme == ''
             if start_is_dir:
                 start_dir = parsed_start.path
             else:
-                start_dir = os.path.dirname(parsed_start.path)
-            abs_path = os.path.abspath(
-                os.path.join(start_dir, parsed_source.path))
+                start_dir = _pathlib.dirname(parsed_start.path)
+            abs_path = _pathlib.abspath(
+                _join(is_path, start_dir, parsed_source.path))
             if parsed_start.scheme != '':
+                if not is_path:
+                    abs_path = abs_path.replace('\\', '/')
+
                 return '{}://{}{}'.format(parsed_start.scheme,
                                           parsed_start.netloc, abs_path)
             else:
@@ -82,5 +127,5 @@ def is_absolute_href(href):
     Returns:
         bool: True if the given HREF is absolute, False if it is relative.
     """
-    parsed = urlparse(href)
-    return parsed.scheme != '' or os.path.isabs(parsed.path)
+    parsed = _urlparse(href)
+    return parsed.scheme != '' or _pathlib.isabs(parsed.path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,8 @@
 import unittest
+import os
+import ntpath
+
+from pystac import utils
 
 from pystac.utils import (make_relative_href, make_absolute_href,
                           is_absolute_href)
@@ -30,6 +34,42 @@ class UtilsTest(unittest.TestCase):
             actual = make_relative_href(source_href, start_href)
             self.assertEqual(actual, expected)
 
+    def test_make_relative_href_windows(self):
+        utils._pathlib = ntpath
+        try:
+            # Test cases of (source_href, start_href, expected)
+            test_cases = [
+                ('C:\\a\\b\\c\\d\\catalog.json', 'C:\\a\\b\\c\\catalog.json',
+                 '.\\d\\catalog.json'),
+                ('C:\\a\\b\\catalog.json', 'C:\\a\\b\\c\\catalog.json',
+                 '..\\catalog.json'),
+                ('C:\\a\\catalog.json', 'C:\\a\\b\\c\\catalog.json',
+                 '..\\..\\catalog.json'),
+                ('a\\b\\c\\catalog.json', 'a\\b\\catalog.json',
+                 '.\\c\\catalog.json'),
+                ('a\\b\\catalog.json', 'a\\b\\c\\catalog.json',
+                 '..\\catalog.json'),
+                ('http://stacspec.org/a/b/c/d/catalog.json',
+                 'http://stacspec.org/a/b/c/catalog.json', './d/catalog.json'),
+                ('http://stacspec.org/a/b/catalog.json',
+                 'http://stacspec.org/a/b/c/catalog.json', '../catalog.json'),
+                ('http://stacspec.org/a/catalog.json',
+                 'http://stacspec.org/a/b/c/catalog.json',
+                 '../../catalog.json'),
+                ('http://stacspec.org/a/catalog.json',
+                 'http://cogeo.org/a/b/c/catalog.json',
+                 'http://stacspec.org/a/catalog.json'),
+                ('http://stacspec.org/a/catalog.json',
+                 'https://stacspec.org/a/b/c/catalog.json',
+                 'http://stacspec.org/a/catalog.json')
+            ]
+
+            for source_href, start_href, expected in test_cases:
+                actual = make_relative_href(source_href, start_href)
+                self.assertEqual(actual, expected)
+        finally:
+            utils._pathlib = os.path
+
     def test_make_absolute_href(self):
         # Test cases of (source_href, start_href, expected)
         test_cases = [
@@ -51,6 +91,35 @@ class UtilsTest(unittest.TestCase):
             actual = make_absolute_href(source_href, start_href)
             self.assertEqual(actual, expected)
 
+    def test_make_absolute_href_windows(self):
+        utils._pathlib = ntpath
+        try:
+            # Test cases of (source_href, start_href, expected)
+            test_cases = [
+                ('item.json', 'C:\\a\\b\\c\\catalog.json',
+                 'c:\\a\\b\\c\\item.json'),
+                ('.\\item.json', 'C:\\a\\b\\c\\catalog.json',
+                 'c:\\a\\b\\c\\item.json'),
+                ('.\\z\\item.json', 'Z:\\a\\b\\c\\catalog.json',
+                 'z:\\a\\b\\c\\z\\item.json'),
+                ('..\\item.json', 'a:\\a\\b\\c\\catalog.json',
+                 'a:\\a\\b\\item.json'),
+                ('item.json', 'HTTPS://stacspec.org/a/b/c/catalog.json',
+                 'https://stacspec.org/a/b/c/item.json'),
+                ('./item.json', 'https://stacspec.org/a/b/c/catalog.json',
+                 'https://stacspec.org/a/b/c/item.json'),
+                ('./z/item.json', 'https://stacspec.org/a/b/c/catalog.json',
+                 'https://stacspec.org/a/b/c/z/item.json'),
+                ('../item.json', 'https://stacspec.org/a/b/c/catalog.json',
+                 'https://stacspec.org/a/b/item.json')
+            ]
+
+            for source_href, start_href, expected in test_cases:
+                actual = make_absolute_href(source_href, start_href)
+                self.assertEqual(actual, expected)
+        finally:
+            utils._pathlib = os.path
+
     def test_is_absolute_href(self):
         # Test cases of (href, expected)
         test_cases = [('item.json', False), ('./item.json', False),
@@ -60,3 +129,18 @@ class UtilsTest(unittest.TestCase):
         for href, expected in test_cases:
             actual = is_absolute_href(href)
             self.assertEqual(actual, expected)
+
+    def test_is_absolute_href_windows(self):
+        utils._pathlib = ntpath
+        try:
+
+            # Test cases of (href, expected)
+            test_cases = [('item.json', False), ('.\\item.json', False),
+                          ('..\\item.json', False), ('c:\\item.json', True),
+                          ('http://stacspec.org/item.json', True)]
+
+            for href, expected in test_cases:
+                actual = is_absolute_href(href)
+                self.assertEqual(actual, expected)
+        finally:
+            utils._pathlib = os.path


### PR DESCRIPTION
The make_absolute_href and make_relative_href methods workfed for
posix paths, but windows path broke the logic. This change accounts
for those paths and adds unit tests to test windows paths.

Fixes #62