### PR TITLE
Respect tzinfo in the provided datetime

### DIFF
--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -133,7 +133,7 @@ def is_absolute_href(href):
 
 
 def datetime_to_str(dt):
-    """Convert a python datetime to an ISO8601 stirng
+    """Convert a python datetime to an ISO8601 string
 
     Args:
         dt (datetime): The datetime to convert.
@@ -143,4 +143,10 @@ def datetime_to_str(dt):
     """
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    return dt.isoformat()
+
+    timestamp = dt.isoformat()
+    zulu = '+00:00'
+    if timestamp.endswith(zulu):
+        timestamp = '{}Z'.format(timestamp[:-len(zulu)])
+
+    return timestamp

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -1,6 +1,7 @@
 import os
 import posixpath
 from urllib.parse import (urlparse, ParseResult as URLParseResult)
+from datetime import timezone
 
 # Allow for modifying the path library for testability
 # (i.e. testing Windows path manipulation on non-Windows systems)
@@ -140,4 +141,6 @@ def datetime_to_str(dt):
     Returns:
         str: The ISO8601 formatted string representing the datetime.
     """
-    return dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -47,4 +47,4 @@ class ItemTest(unittest.TestCase):
 
         formatted_time = item.to_dict()['properties']['datetime']
 
-        self.assertEqual('2016-05-03T13:22:30.040000+00:00', formatted_time)
+        self.assertEqual('2016-05-03T13:22:30.040000Z', formatted_time)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -47,4 +47,4 @@ class ItemTest(unittest.TestCase):
 
         formatted_time = item.to_dict()['properties']['datetime']
 
-        self.assertEqual('2016-05-03T13:22:30Z', formatted_time)
+        self.assertEqual('2016-05-03T13:22:30.040000+00:00', formatted_time)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -149,9 +149,9 @@ class UtilsTest(unittest.TestCase):
     def test_datetime_to_str(self):
         cases = (
             ('timezone naive, assume utc', datetime(2000, 1, 1),
-             '2000-01-01T00:00:00+00:00'),
+             '2000-01-01T00:00:00Z'),
             ('timezone aware, utc', datetime(2000, 1, 1, tzinfo=timezone.utc),
-             '2000-01-01T00:00:00+00:00'),
+             '2000-01-01T00:00:00Z'),
             ('timezone aware, utc -7',
              datetime(2000, 1, 1, tzinfo=timezone(timedelta(hours=-7))),
              '2000-01-01T00:00:00-07:00'),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import ntpath
+from datetime import datetime, timezone, timedelta
 
 from pystac import utils
 
@@ -144,3 +145,19 @@ class UtilsTest(unittest.TestCase):
                 self.assertEqual(actual, expected)
         finally:
             utils._pathlib = os.path
+
+    def test_datetime_to_str(self):
+        cases = (
+            ('timezone naive, assume utc', datetime(2000, 1, 1),
+             '2000-01-01T00:00:00+00:00'),
+            ('timezone aware, utc', datetime(2000, 1, 1, tzinfo=timezone.utc),
+             '2000-01-01T00:00:00+00:00'),
+            ('timezone aware, utc -7',
+             datetime(2000, 1, 1, tzinfo=timezone(timedelta(hours=-7))),
+             '2000-01-01T00:00:00-07:00'),
+        )
+
+        for title, dt, expected in cases:
+            with self.subTest(title=title):
+                got = utils.datetime_to_str(dt)
+                self.assertEqual(expected, got)


### PR DESCRIPTION
It looks like the fix for #56 got closer to being able to represent dates as [RFC-3339](https://tools.ietf.org/html/rfc3339#section-5.6) formatted strings.  However, it looks like any `tzinfo` in the provided datetime is ignored.  So the current `utils.datetime_to_str()` function works for timezone naive datetimes, but not for timezone aware datetimes.

This branch proposes to treat timezone naive datetimes as UTC datetimes (in line with the current assumptions) but respects any `tzinfo` in the provided datetime.