### PR TITLE
Fixed catalog and collection clone logic to avoid dupe root link

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -317,7 +317,16 @@ class Catalog(STACObject):
                         title=self.title)
         clone._resolved_objects.cache(clone)
 
-        clone.add_links([l.clone() for l in self.links])
+        for l in self.links:
+            if l.rel == 'root':
+                # Catalog __init__ sets correct root to clone; don't reset
+                # if the root link points to self
+                root_is_self = l.is_resolved() and l.target is self
+                if not root_is_self:
+                    clone.set_root(None)
+                    clone.add_link(l.clone())
+            else:
+                clone.add_link(l.clone())
 
         return clone
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -118,7 +118,16 @@ class Collection(Catalog):
 
         clone._resolved_objects.cache(clone)
 
-        clone.add_links([l.clone() for l in self.links])
+        for l in self.links:
+            if l.rel == 'root':
+                # Collection __init__ sets correct root to clone; don't reset
+                # if the root link points to self
+                root_is_self = l.is_resolved() and l.target is self
+                if not root_is_self:
+                    clone.set_root(None)
+                    clone.add_link(l.clone())
+            else:
+                clone.add_link(l.clone())
 
         return clone
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from tempfile import TemporaryDirectory
 from datetime import datetime
+from collections import defaultdict
 
 from pystac import (Catalog, CatalogType, STAC_VERSION, LinkType, Item, Asset,
                     LabelItem, LabelClasses, MediaType)
@@ -102,6 +103,49 @@ class CatalogTest(unittest.TestCase):
         children = list(catalog.get_children())
         self.assertEqual(len(children), 1)
         self.assertEqual(children[0].description, 'test3')
+
+    def test_clone_generates_correct_links(self):
+        catalogs = [
+            TestCases.test_case_1(),
+            TestCases.test_case_2(),
+            TestCases.test_case_3()
+        ]
+
+        for catalog in catalogs:
+            expected_link_types_to_counts = {}
+            actual_link_types_to_counts = {}
+
+            for root, _, items in catalog.walk():
+                expected_link_types_to_counts[root.id] = defaultdict(int)
+                actual_link_types_to_counts[root.id] = defaultdict(int)
+
+                for link in root.get_links():
+                    expected_link_types_to_counts[root.id][link.rel] += 1
+
+                for link in root.clone().get_links():
+                    actual_link_types_to_counts[root.id][link.rel] += 1
+
+                for item in items:
+                    expected_link_types_to_counts[item.id] = defaultdict(int)
+                    actual_link_types_to_counts[item.id] = defaultdict(int)
+                    for link in item.get_links():
+                        expected_link_types_to_counts[item.id][link.rel] += 1
+                    for link in item.get_links():
+                        actual_link_types_to_counts[item.id][link.rel] += 1
+
+            self.assertEqual(set(expected_link_types_to_counts.keys()),
+                             set(actual_link_types_to_counts.keys()))
+            for obj_id in actual_link_types_to_counts:
+                expected_counts = expected_link_types_to_counts[obj_id]
+                actual_counts = actual_link_types_to_counts[obj_id]
+                self.assertEqual(set(expected_counts.keys()),
+                                 set(actual_counts.keys()))
+                for rel in expected_counts:
+                    self.assertEqual(
+                        actual_counts[rel], expected_counts[rel],
+                        'Clone of {} has {} {} links, original has {}'.format(
+                            obj_id, actual_counts[rel], rel,
+                            expected_counts[rel]))
 
     def test_map_items(self):
         def item_mapper(item):


### PR DESCRIPTION
The clone methods on catalog and collection create a new version of the STAC object and set the links on the clone manually. The problem with this is that the constructor of the Catalog sets the root link to itself - this is because a root link is required on a catalog, so a new instance should always link to itself as the root. This PR adds some additional logic to ensure that there is only one root link set in the clone. If the Catalog's root link is set to itself, then the root link of the clone will be set to the clone.

Fixes #63