### PR TITLE
Fix issue with iteration of children in catalog.walk

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -475,7 +475,7 @@ class Catalog(STACObject):
         items = self.get_items()
 
         yield (self, children, items)
-        for child in children:
+        for child in self.get_children():
             yield from child.walk()
 
     def _object_links(self):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -104,6 +104,35 @@ class CatalogTest(unittest.TestCase):
         self.assertEqual(len(children), 1)
         self.assertEqual(children[0].description, 'test3')
 
+    def test_walk_iterates_correctly(self):
+        catalogs = [
+            TestCases.test_case_1(),
+            TestCases.test_case_2(),
+            TestCases.test_case_3()
+        ]
+
+        def test_catalog(cat):
+            expected_catalog_iterations = 1
+            actual_catalog_iterations = 0
+            with self.subTest(title='Testing catalog {}'.format(cat.id)):
+                for root, children, items in cat.walk():
+                    actual_catalog_iterations += 1
+                    expected_catalog_iterations += len(
+                        list(root.get_children()))
+
+                    self.assertEqual(set([c.id for c in root.get_children()]),
+                                     set([c.id for c in children]),
+                                     'Children unequal')
+                    self.assertEqual(set([c.id for c in root.get_items()]),
+                                     set([c.id for c in items]),
+                                     'Items unequal')
+
+                self.assertEqual(actual_catalog_iterations,
+                                 expected_catalog_iterations)
+
+        for cat in catalogs:
+            test_catalog(cat)
+
     def test_clone_generates_correct_links(self):
         catalogs = [
             TestCases.test_case_1(),


### PR DESCRIPTION
The `catalog.walk` method was iterating over the iterator that is previously `yield`ed to the caller, so if the caller iterated over the children, it would empty the iterator and `walk` would not keep walking.

This fixes this issue by using a different iterator for the internal walk of the catalog's children. 