### PR TITLE
allow v0.7.0 sar items to fit in version range

### DIFF
--- a/pystac/serialization/identify.py
+++ b/pystac/serialization/identify.py
@@ -137,7 +137,7 @@ def _identify_stac_extensions(object_type, d, version_range):
                         'sar:pixel_spacing', 'sar:looks'
                 ]:
                     if prop in d['properties']:
-                        if not isinstance(d['properties'][prop], list):
+                        if isinstance(d['properties'][prop], list):
                             version_range.set_max('0.6.2')
             if version_range.contains('0.7.0'):
                 for prop in [

--- a/tests/data-files/examples/0.7.0/extensions/sar/examples/sentinel1.json
+++ b/tests/data-files/examples/0.7.0/extensions/sar/examples/sentinel1.json
@@ -1,0 +1,94 @@
+{
+    "id": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616",
+    "type": "Feature",
+    "bbox": [-70.275032,-64.72924,-65.087479,-51.105831],
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [-67.071648,-64.72924],
+          [-65.087479,-56.674374],
+          [-68.033211,-51.105831],
+          [-70.275032,-59.805672],
+          [-67.071648,-64.72924]
+        ]
+      ]
+    },
+    "properties": {
+      "datetime": "2018-11-03T23:58:55.617217Z",
+      "dtr:start_datetime": "2018-11-03T23:58:55.121559Z",
+      "dtr:end_datetime": "2018-11-03T23:59:55.112875Z",
+      "sar:platform": "Sentinel-1A",
+      "sar:constellation": "Sentinel-1",
+      "sar:instrument": "C-SAR",
+      "sar:instrument_mode": "EW",
+      "sar:polarization": ["HH"],
+      "sar:resolution_range": 50,
+      "sar:resolution_azimuth": 50,
+      "sar:pixel_spacing_range": 25,
+      "sar:pixel_spacing_azimuth": 25,
+      "sar:looks_range": 3,
+      "sar:looks_azimuth": 1,
+      "sar:looks_equivalent_number": 2.7,
+      "sar:frequency_band": "C",
+      "sar:center_wavelength": 5.546576466235,
+      "sar:center_frequency": 5.405,
+      "sar:pass_direction": "ascending",
+      "sar:absolute_orbit": 24430,
+      "sar:relative_orbit": 33,
+      "sar:type": "GRD",
+      "sar:bands": [
+        {
+          "name": "band_1",
+          "polarization": "HH"
+        }
+      ]
+    },
+    "assets": {
+      "noises": {
+        "href": "./annotation/calibration/noise-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
+        "title": "Calibration Schema",
+        "type": "text/xml",
+        "checksum:md5": "a30d1711e81a4b11ef67b28744321659"
+      },
+      "calibrations": {
+        "href": "./annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
+        "title": "Noise Schema",
+        "type": "text/xml",
+        "checksum:md5": "4fc5351af67db0b8f1746efe421a05e4"
+      },
+      "products": {
+        "href": "./annotation/s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
+        "title": "Product Schema",
+        "type": "text/xml",
+        "checksum:md5": "7a7f2588a85362b9beea2a12d4514d45"
+      },
+      "measurement": {
+        "href": "./measurement/s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.tiff",
+        "title": "Measurements",
+        "type": "image/tiff",
+        "sar:bands": [0],
+        "checksum:md5": "163700a8a6501eccd00b6d3b44ddaed0"
+      },
+      "thumbnail": {
+        "href": "./preview/quick-look.png",
+        "title": "Thumbnail",
+        "type": "image/png",
+        "checksum:md5": "f52acd32b09769d3b1871b420789456c"
+      }
+    },
+    "links": [
+      {
+        "rel": "self",
+        "href": "https://example.com/collections/sentinel-1/items/S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616"
+      },
+      {
+        "rel": "parent",
+        "href": "https://example.com/collections/sentinel-1"
+      },
+      {
+        "rel": "root",
+        "href": "https://example.com/collections"
+      }
+    ]
+  }

--- a/tests/data-files/examples/example-info.csv
+++ b/tests/data-files/examples/example-info.csv
@@ -62,3 +62,4 @@
 "iserv-0.6.1/2013/03/catalog.json","CATALOG","0.6.1","",""
 "iserv-0.6.1/2013/03/27/catalog.json","CATALOG","0.6.1","",""
 "iserv-0.6.1/2013/03/27/IP0201303271418280967S05834W.json","ITEM","0.6.1","eo",""
+"0.7.0/extensions/sar/examples/sentinel1.json","ITEM","0.7.0","sar|dtr",""


### PR DESCRIPTION
v0.7.0 items with sar extension properties are incorrectly categorized as v0.6.2 due to a rogue "not" in serialization. These properties were lists prior to v0.7.0. `sar:absolute_orbit` is most problematic, as it's the only shared attribute name between the properties that turned from list in 0.6.2 to integer in 0.7.0.

0.6.2: https://github.com/radiantearth/stac-spec/tree/v0.6.2/extensions/sar
0.7.0: https://github.com/radiantearth/stac-spec/tree/v0.7.0/extensions/sar

Test data from: https://github.com/radiantearth/stac-spec/blob/v0.7.0/extensions/sar/examples/sentinel1.json