### PR TITLE
Fixed issue with datetime-range extension name in test, style fix.

### DIFF
--- a/tests/data-files/examples/example-info.csv
+++ b/tests/data-files/examples/example-info.csv
@@ -64,4 +64,4 @@
 "iserv-0.6.1/2013/03/catalog.json","CATALOG","0.6.1","",""
 "iserv-0.6.1/2013/03/27/catalog.json","CATALOG","0.6.1","",""
 "iserv-0.6.1/2013/03/27/IP0201303271418280967S05834W.json","ITEM","0.6.1","eo",""
-"0.7.0/extensions/sar/examples/sentinel1.json","ITEM","0.7.0","sar|dtr",""
+"0.7.0/extensions/sar/examples/sentinel1.json","ITEM","0.7.0","sar|datetime-range",""

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -102,32 +102,22 @@ class CatalogTest(unittest.TestCase):
         self.assertEqual(children[0].description, 'test3')
 
     def test_walk_iterates_correctly(self):
-        catalogs = [
-            TestCases.test_case_1(),
-            TestCases.test_case_2(),
-            TestCases.test_case_3()
-        ]
-
         def test_catalog(cat):
             expected_catalog_iterations = 1
             actual_catalog_iterations = 0
             with self.subTest(title='Testing catalog {}'.format(cat.id)):
                 for root, children, items in cat.walk():
                     actual_catalog_iterations += 1
-                    expected_catalog_iterations += len(
-                        list(root.get_children()))
+                    expected_catalog_iterations += len(list(root.get_children()))
 
                     self.assertEqual(set([c.id for c in root.get_children()]),
-                                     set([c.id for c in children]),
-                                     'Children unequal')
+                                     set([c.id for c in children]), 'Children unequal')
                     self.assertEqual(set([c.id for c in root.get_items()]),
-                                     set([c.id for c in items]),
-                                     'Items unequal')
+                                     set([c.id for c in items]), 'Items unequal')
 
-                self.assertEqual(actual_catalog_iterations,
-                                 expected_catalog_iterations)
+                self.assertEqual(actual_catalog_iterations, expected_catalog_iterations)
 
-        for cat in catalogs:
+        for cat in TestCases.all_test_catalogs():
             test_catalog(cat)
 
     def test_clone_generates_correct_links(self):


### PR DESCRIPTION
It's not super clear if "dtr" or "datetime-range" belongs in the "stac_extensions" list for the item; however, the example for the 0.8.1 STAC spec has it with "datetime-range". This fixed the examples
info so that the proper stac extension name is matched against.

The dtr extension is dropped in future releases of STAC, so this ambiguity should be less of an issue moving forward.

Also, fixed a style issue with on of the tests.