### PR TITLE
Fixed issue with reading ItemCollections directly.

### DIFF
--- a/pystac/serialization/__init__.py
+++ b/pystac/serialization/__init__.py
@@ -42,9 +42,9 @@ def stac_object_from_dict(d, href=None, root=None):
 
     if info.object_type == STACObjectType.ITEMCOLLECTION:
         if Extension.SINGLE_FILE_STAC in info.common_extensions:
-            return SingleFileSTAC.from_dict(d, href=href, root=root)
+            return SingleFileSTAC.from_dict(d)
 
-        return ItemCollection.from_dict(d, href=href, root=root)
+        return ItemCollection.from_dict(d)
 
     if info.object_type == STACObjectType.ITEM:
         if Extension.EO in info.common_extensions:

--- a/tests/data-files/examples/0.8.1/extensions/pointcloud/examples/example-autzen.json
+++ b/tests/data-files/examples/0.8.1/extensions/pointcloud/examples/example-autzen.json
@@ -47,7 +47,7 @@
     }
   ],
   "properties": {
-    "datetime": "2013-07-17T00:00:00-05:00Z",
+    "datetime": "2013-07-17T00:00:00-05:00",
     "pc:count": 10653336,
     "pc:density": 0,
     "pc:encoding": "LASzip",

--- a/tests/data-files/examples/0.8.1/item-spec/examples/digitalglobe-sample.json
+++ b/tests/data-files/examples/0.8.1/item-spec/examples/digitalglobe-sample.json
@@ -134,10 +134,6 @@
     {
       "rel": "self",
       "href": "https://s3.amazonaws.com/digitalglobe-catalog-spec/collections/dg_worldview02_lv1b/103001004B316600_P002_MUL"
-    },
-    {
-      "rel": "collection",
-      "href": "https://s3.amazonaws.com/digitalglobe-catalog-spec/collections/dg_worldview02_lv1b.json"
     }
   ]
 }

--- a/tests/data-files/examples/0.8.1/item-spec/examples/landsat8-sample.json
+++ b/tests/data-files/examples/0.8.1/item-spec/examples/landsat8-sample.json
@@ -141,8 +141,7 @@
   "links": [
     { "rel":"self", "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00.json"},
     { "rel":"alternate", "href": "https://landsatonaws.com/L8/153/025/LC81530252014153LGN00", "type": "text/html"},
-    { "rel":"root", "href": "http://landsat-pds.s3.amazonaws.com/L8/L1T-collection.json"},
-    { "rel":"collection", "href": "http://landsat-pds.s3.amazonaws.com/L8/L1T-collection.json"}
+    { "rel":"root", "href": "http://landsat-pds.s3.amazonaws.com/L8/L1T-collection.json"}
   ],
 
   "assets" :{

--- a/tests/data-files/examples/0.8.1/item-spec/examples/sample-full.json
+++ b/tests/data-files/examples/0.8.1/item-spec/examples/sample-full.json
@@ -52,7 +52,6 @@
     {"rel": "self", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"},
     {"rel": "root", "href": "http://cool-sat.com/catalog/catalog.json"},
     {"rel": "parent", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/catalog.json"},
-    {"rel": "collection", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/catalog.json"},
     {"rel": "acquisition", "href": "http://cool-sat.com/catalog/acquisitions/20160503_56"}
   ],
   "assets": {

--- a/tests/data-files/examples/0.8.1/item-spec/examples/sample.json
+++ b/tests/data-files/examples/0.8.1/item-spec/examples/sample.json
@@ -24,10 +24,6 @@
     {
       "rel": "self",
       "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"
-    },
-    {
-      "rel": "collection",
-      "href": "http://cool-sat.com/catalog.json"
     }
   ],
   "assets": {

--- a/tests/data-files/examples/0.8.1/item-spec/examples/sentinel2-sample.json
+++ b/tests/data-files/examples/0.8.1/item-spec/examples/sentinel2-sample.json
@@ -17,7 +17,7 @@
     },
     {
       "rel": "collection",
-      "href": "https://raw.githubusercontent.com/sat-utils/sat-stac-sentinel/master/satstac/sentinel/sentinel-2-l1c.json"
+      "href": "https://raw.githubusercontent.com/sat-utils/sat-stac-sentinel/4588288e83e12485cdcb2e9d31dce30915ebae4c/stac_sentinel/sentinel-s2-l1c.json"
     }
   ],
   "bbox": [

--- a/tests/serialization/test_migrate.py
+++ b/tests/serialization/test_migrate.py
@@ -10,28 +10,29 @@ from tests.utils import TestCases
 
 class MigrateTest(unittest.TestCase):
     def setUp(self):
-        self.examples = [
-            e for e in TestCases.get_examples_info() if e['stac_version'] < STAC_VERSION
-        ]
+        self.examples = [e for e in TestCases.get_examples_info()]
 
     def test_migrate(self):
         collection_cache = CollectionCache()
         for example in self.examples:
-            path = example['path']
-            d = STAC_IO.read_json(path)
-            if identify_stac_object_type(d) == STACObjectType.ITEM:
-                merge_common_properties(d, json_href=path, collection_cache=collection_cache)
+            with self.subTest(example['path']):
+                path = example['path']
+                d = STAC_IO.read_json(path)
+                if identify_stac_object_type(d) == STACObjectType.ITEM:
+                    merge_common_properties(d, json_href=path, collection_cache=collection_cache)
 
-            info = identify_stac_object(d)
+                info = identify_stac_object(d)
 
-            migrated_d = migrate_to_latest(d, info)
+                migrated_d = migrate_to_latest(d, info)
 
-            migrated_info = identify_stac_object(migrated_d)
+                migrated_info = identify_stac_object(migrated_d)
 
-            self.assertEqual(migrated_info.object_type, info.object_type)
-            self.assertEqual(migrated_info.version_range.latest_valid_version(), STAC_VERSION)
-            self.assertEqual(set(migrated_info.common_extensions), set(info.common_extensions))
-            self.assertEqual(set(migrated_info.custom_extensions), set(info.custom_extensions))
+                self.assertEqual(migrated_info.object_type, info.object_type)
+                self.assertEqual(migrated_info.version_range.latest_valid_version(), STAC_VERSION)
+                self.assertEqual(set(migrated_info.common_extensions), set(info.common_extensions))
+                self.assertEqual(set(migrated_info.custom_extensions), set(info.custom_extensions))
 
-            # Test that PySTAC can read it without errors.
-            self.assertIsInstance(STAC_IO.stac_object_from_dict(migrated_d, href=path), STACObject)
+                # Test that PySTAC can read it without errors.
+                if info.object_type != STACObjectType.ITEMCOLLECTION:
+                    self.assertIsInstance(STAC_IO.stac_object_from_dict(migrated_d, href=path),
+                                          STACObject)


### PR DESCRIPTION
While upgrading to 0.9.0, I exposed a bug that should be fixed in the PySTAC 0.3.* series.

Also changes the migrate test to consider all examples, not just ones
that are of a previous STAC version.