### PR TITLE
fix bug in `make_absolute_href`

### DIFF
--- a/pystac/eo.py
+++ b/pystac/eo.py
@@ -374,14 +374,14 @@ class Band:
             as measured at half the maximum transmission, in micrometers (μm).
     """
     def __init__(
-            self,
-            name=None,
-            common_name=None,
-            description=None,
-            gsd=None,
-            accuracy=None,
-            center_wavelength=None,
-            full_width_half_max=None,
+        self,
+        name=None,
+        common_name=None,
+        description=None,
+        gsd=None,
+        accuracy=None,
+        center_wavelength=None,
+        full_width_half_max=None,
     ):
         self.name = name
         self.common_name = common_name

--- a/pystac/eo.py
+++ b/pystac/eo.py
@@ -374,14 +374,14 @@ class Band:
             as measured at half the maximum transmission, in micrometers (μm).
     """
     def __init__(
-        self,
-        name=None,
-        common_name=None,
-        description=None,
-        gsd=None,
-        accuracy=None,
-        center_wavelength=None,
-        full_width_half_max=None,
+            self,
+            name=None,
+            common_name=None,
+            description=None,
+            gsd=None,
+            accuracy=None,
+            center_wavelength=None,
+            full_width_half_max=None,
     ):
         self.name = name
         self.common_name = common_name

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -87,8 +87,12 @@ def make_absolute_href(source_href, start_href=None, start_is_dir=False):
 
     Returns:
         str: The absolute HREF. If the source_href is already an absolute href,
-        then it will be returned unchanged.
+        then it will be returned unchanged. If the source_href it None, it will
+        return None.
     """
+    if source_href == None:
+        return None
+
     if start_href is None:
         start_href = os.getcwd()
         start_is_dir = True

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -90,7 +90,7 @@ def make_absolute_href(source_href, start_href=None, start_is_dir=False):
         then it will be returned unchanged. If the source_href it None, it will
         return None.
     """
-    if source_href == None:
+    if source_href is None:
         return None
 
     if start_href is None:


### PR DESCRIPTION
I was getting an error (stack trace below) running the tutorial notebook. Looks like PySTAC wasn't able to convert an item to a python dict if it didn't have a self href defined. This PR modified `make_absolute_href` to fix this issue, returning `None` rather than throwing an error.

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-19-8fc29b8a3af9> in <module>
      1 import json
----> 2 print(json.dumps(item.to_dict(), indent=4))

~/.local/lib/python3.6/site-packages/pystac/item.py in to_dict(self, include_self_link)
    178             'geometry': self.geometry,
    179             'bbox': self.bbox,
--> 180             'links': [l.to_dict() for l in links],
    181             'assets': assets
    182         }

~/.local/lib/python3.6/site-packages/pystac/item.py in <listcomp>(.0)
    178             'geometry': self.geometry,
    179             'bbox': self.bbox,
--> 180             'links': [l.to_dict() for l in links],
    181             'assets': assets
    182         }

~/.local/lib/python3.6/site-packages/pystac/link.py in to_dict(self)
    191         d = {'rel': self.rel}
    192 
--> 193         d['href'] = self.get_href()
    194 
    195         if self.media_type is not None:

~/.local/lib/python3.6/site-packages/pystac/link.py in get_href(self)
    109                 href = make_relative_href(href, self.owner.get_self_href())
    110         else:
--> 111             href = self.get_absolute_href()
    112 
    113         return href

~/.local/lib/python3.6/site-packages/pystac/link.py in get_absolute_href(self)
    127 
    128         if self.owner is not None:
--> 129             href = make_absolute_href(href, self.owner.get_self_href())
    130 
    131         return href

~/.local/lib/python3.6/site-packages/pystac/utils.py in make_absolute_href(source_href, start_href, start_is_dir)
     94         start_is_dir = True
     95 
---> 96     parsed_source = _urlparse(source_href)
     97     if parsed_source.scheme == '':
     98         if not _pathlib.isabs(parsed_source.path):

~/.local/lib/python3.6/site-packages/pystac/utils.py in _urlparse(href)
     16     """
     17     parsed = urlparse(href)
---> 18     if parsed.scheme != '' and href.lower().startswith('{}:\\'.format(parsed.scheme)):
     19         return URLParseResult(scheme='',
     20                               netloc='',

AttributeError: 'NoneType' object has no attribute 'lower'
```