### PR TITLE
Update to 0.9

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -133,6 +133,13 @@ Asset
    :members:
    :undoc-members:
 
+CommonMetadata
+~~~~~
+
+.. autoclass:: pystac.CommonMetadata
+   :members:
+   :undoc-members:
+
 ItemCollection
 ~~~~~~~~~~~~~~
 

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -21,7 +21,7 @@ from pystac.media_type import MediaType
 from pystac.link import (Link, LinkType)
 from pystac.catalog import (Catalog, CatalogType)
 from pystac.collection import (Collection, Extent, SpatialExtent, TemporalExtent, Provider)
-from pystac.item import (Item, Asset)
+from pystac.item import (Item, Asset, CommonMetadata)
 from pystac.item_collection import ItemCollection
 from pystac.single_file_stac import SingleFileSTAC
 from pystac.eo import *

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -24,11 +24,10 @@ class Collection(Catalog):
         href (str or None): Optional HREF for this collection, which be set as the collection's
             self link's HREF.
         license (str):  Collection's license(s) as a `SPDX License identifier
-            <https://spdx.org/licenses/>`_ or `expression
-            <https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60>`_. Defaults
-            to 'proprietary'.
+            <https://spdx.org/licenses/>`_, `various`, or `proprietary`. If collection includes
+            data with multiple different licenses, use `various` and add a link for each.
+            Defaults to 'proprietary'.
         keywords (List[str]): Optional list of keywords describing the collection.
-        version (str): Optional version of the Collection.
         providers (List[Provider]): Optional list of providers of this Collection.
         properties (dict): Optional dict of common fields across referenced items.
         summaries (dict): An optional map of property summaries,
@@ -42,7 +41,6 @@ class Collection(Catalog):
         title (str or None): Optional short descriptive one-line title for the collection.
         stac_extensions (List[str]): Optional list of extensions the Collection implements.
         keywords (List[str] or None): Optional list of keywords describing the collection.
-        version (str or None): Optional version of the Collection.
         providers (List[Provider] or None): Optional list of providers of this Collection.
         properties (dict or None): Optional dict of common fields across referenced items.
         summaries (dict or None): An optional map of property summaries,
@@ -61,7 +59,6 @@ class Collection(Catalog):
                  href=None,
                  license='proprietary',
                  keywords=None,
-                 version=None,
                  providers=None,
                  properties=None,
                  summaries=None):
@@ -71,7 +68,6 @@ class Collection(Catalog):
 
         self.stac_extensions = stac_extensions
         self.keywords = keywords
-        self.version = version
         self.providers = providers
         self.properties = properties
         self.summaries = summaries
@@ -91,8 +87,6 @@ class Collection(Catalog):
             d['stac_extensions'] = self.stac_extensions
         if self.keywords is not None:
             d['keywords'] = self.keywords
-        if self.version is not None:
-            d['version'] = self.version
         if self.providers is not None:
             d['providers'] = list(map(lambda x: x.to_dict(), self.providers))
         if self.properties is not None:
@@ -110,7 +104,6 @@ class Collection(Catalog):
                            license=self.license,
                            stac_extensions=self.stac_extensions,
                            keywords=self.keywords,
-                           version=self.version,
                            providers=self.providers,
                            properties=self.properties,
                            summaries=self.summaries)
@@ -139,7 +132,6 @@ class Collection(Catalog):
         title = d.get('title')
         stac_extensions = d.get('stac_extensions')
         keywords = d.get('keywords')
-        version = d.get('version')
         providers = d.get('providers')
         if providers is not None:
             providers = list(map(lambda x: Provider.from_dict(x), providers))
@@ -153,7 +145,6 @@ class Collection(Catalog):
                                 license=license,
                                 stac_extensions=stac_extensions,
                                 keywords=keywords,
-                                version=version,
                                 providers=providers,
                                 properties=properties,
                                 summaries=summaries)

--- a/pystac/eo.py
+++ b/pystac/eo.py
@@ -196,6 +196,8 @@ class EOAsset(Asset):
             text representation.
         media_type (str): Optional description of the media type. Registered Media Types
             are preferred. See :class:`~pystac.MediaType` for common media types.
+        roles ([str]): Optional, Semantic roles (i.e. thumbnail, overview, data, metadata)
+            of the asset.
         properties (dict): Optional, additional properties for this asset.
 
     Attributes:
@@ -207,13 +209,22 @@ class EOAsset(Asset):
             text representation.
         media_type (str): Optional description of the media type. Registered Media Types
             are preferred. See :class:`~pystac.MediaType` for common media types.
+        roles ([str]): Optional, Semantic roles (i.e. thumbnail, overview, data, metadata)
+            of the asset.
         properties (dict): Optional, additional properties for this asset. This is used by
             extensions as a way to serialize and deserialize properties on asset
             object JSON.
         owner (Item or None): The Item this asset belongs to.
     """
-    def __init__(self, href, bands, title=None, description=None, media_type=None, properties=None):
-        super().__init__(href, title, description, media_type, properties)
+    def __init__(self,
+                 href,
+                 bands,
+                 title=None,
+                 description=None,
+                 media_type=None,
+                 roles=None,
+                 properties=None):
+        super().__init__(href, title, description, media_type, roles, properties)
         self.bands = bands
 
     @staticmethod
@@ -263,7 +274,14 @@ class EOAsset(Asset):
         properties = None
         if any(a.properties):
             properties = a.properties
-        return cls(a.href, bands, a.title, a.description, a.media_type, properties)
+
+        return cls(href=a.href,
+                   bands=bands,
+                   title=a.title,
+                   description=a.description,
+                   media_type=a.media_type,
+                   roles=a.roles,
+                   properties=properties)
 
     def to_dict(self):
         """Generate a dictionary representing the JSON of this EOAsset.
@@ -282,6 +300,7 @@ class EOAsset(Asset):
                        description=self.description,
                        media_type=self.media_type,
                        bands=self.bands,
+                       roles=self.roles,
                        properties=self.properties)
 
     def __repr__(self):
@@ -314,10 +333,6 @@ class Band:
             to search for bands across instruments. See the `list of accepted common names
             <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
         description (str): Description to fully explain the band.
-        gsd (float): Ground Sample Distance, the nominal distance between pixel
-            centers available, in meters. Defaults to the EOItems' eo:gsd if not provided.
-        accuracy (float): The expected error between the measured location and the
-            true location of a pixel, in meters on the ground.
         center_wavelength (float): The center wavelength of the band, in micrometers (μm).
         full_width_half_max (float): Full width at half maximum (FWHM). The width of the band,
             as measured at half the maximum transmission, in micrometers (μm).
@@ -328,10 +343,6 @@ class Band:
             to search for bands across instruments. See the `list of accepted common names
             <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
         description (str): Description to fully explain the band.
-        gsd (float): Ground Sample Distance, the nominal distance between pixel
-            centers available, in meters. Defaults to the EOItems' eo:gsd if not provided.
-        accuracy (float): The expected error between the measured location and the
-            true location of a pixel, in meters on the ground.
         center_wavelength (float): The center wavelength of the band, in micrometers (μm).
         full_width_half_max (float): Full width at half maximum (FWHM). The width of the band,
             as measured at half the maximum transmission, in micrometers (μm).
@@ -340,15 +351,11 @@ class Band:
                  name=None,
                  common_name=None,
                  description=None,
-                 gsd=None,
-                 accuracy=None,
                  center_wavelength=None,
                  full_width_half_max=None):
         self.name = name
         self.common_name = common_name
         self.description = description
-        self.gsd = gsd
-        self.accuracy = accuracy
         self.center_wavelength = center_wavelength
         self.full_width_half_max = full_width_half_max
 
@@ -412,17 +419,13 @@ class Band:
         """
         name = d.get('name')
         common_name = d.get('common_name')
-        gsd = d.get('gsd')
         center_wavelength = d.get('center_wavelength')
         full_width_half_max = d.get('full_width_half_max')
         description = d.get('description')
-        accuracy = d.get('accuracy')
 
         return Band(name=name,
                     common_name=common_name,
                     description=description,
-                    gsd=gsd,
-                    accuracy=accuracy,
                     center_wavelength=center_wavelength,
                     full_width_half_max=full_width_half_max)
 
@@ -437,14 +440,10 @@ class Band:
             d['name'] = self.name
         if self.common_name:
             d['common_name'] = self.common_name
-        if self.gsd:
-            d['gsd'] = self.gsd
         if self.center_wavelength:
             d['center_wavelength'] = self.center_wavelength
         if self.full_width_half_max:
             d['full_width_half_max'] = self.full_width_half_max
         if self.description:
             d['description'] = self.description
-        if self.accuracy:
-            d['accuracy'] = self.accuracy
         return deepcopy(d)

--- a/pystac/eo.py
+++ b/pystac/eo.py
@@ -54,9 +54,7 @@ class EOItem(Item):
         collection_id (str or None): The Collection ID that this item belongs to, if any.
 
     """
-    _EO_FIELDS = [
-        'gsd', 'bands', 'epsg', 'cloud_cover'
-    ]
+    _EO_FIELDS = ['gsd', 'bands', 'epsg', 'cloud_cover']
 
     @staticmethod
     def _eo_key(key):
@@ -338,16 +336,14 @@ class Band:
         full_width_half_max (float): Full width at half maximum (FWHM). The width of the band,
             as measured at half the maximum transmission, in micrometers (μm).
     """
-    def __init__(
-            self,
-            name=None,
-            common_name=None,
-            description=None,
-            gsd=None,
-            accuracy=None,
-            center_wavelength=None,
-            full_width_half_max=None,
-    ):
+    def __init__(self,
+                 name=None,
+                 common_name=None,
+                 description=None,
+                 gsd=None,
+                 accuracy=None,
+                 center_wavelength=None,
+                 full_width_half_max=None):
         self.name = name
         self.common_name = common_name
         self.description = description

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -264,7 +264,15 @@ class Item(STACObject):
         return CommonMetadata(self.properties)
 
     def set_common_metadata(self, common_metadata, override=False):
-        for k, v in common_metadata.to_dict().items():
+        """Update common metadata properties within an item from a CommonMetadata
+        object
+
+        Args:
+            common_metadata (CommonMetadat): The CommonMetadata object which
+                will define fields in the item's properties
+            override (bool, optional): Whether or not to override . Defaults to False.
+        """
+        for k, v in common_metadata.properties.items():
             if k in self.properties:
                 if override:
                     self.properties[k] = v
@@ -425,8 +433,9 @@ class CommonMetadata:
             common metadata fields in
 
     Attributes:
+        properties (dict): Dict of all common metadata attributes
         title (str): Human readable title describing the item
-        description (str): Detailed, description of the item
+        description (str): Detailed description of the item
         start_datetime (datetime): Start date and time for the item
         end_datetime (datetime): End date and time for the item
         license (str): Item's license(s), either SPDX identifier of 'various'
@@ -442,46 +451,195 @@ class CommonMetadata:
             updated
     """
     def __init__(self, properties):
-        if properties is None:
-            properties = {}
+        self.properties = properties
 
-        # Basics
-        self.title = properties.get('title')
-        self.description = properties.get('description')
+    # Basics
+    @property
+    def title(self):
+        """Get or set the item's title
 
-        # Date and Time Range
-        self.start_datetime = properties.get('start_datetime')
-        if self.start_datetime:
-            self.start_datetime = dateutil.parser.parse(self.start_datetime)
-        self.end_datetime = properties.get('end_datetime')
-        if self.end_datetime:
-            self.end_datetime = dateutil.parser.parse(self.end_datetime)
+        Returns:
+            str: Human readable title describing the item
+        """
+        return self.properties.get('title')
 
-        # License
-        self.license = properties.get('license')
+    @title.setter
+    def title(self, v):
+        self.properties['title'] = v
 
-        # Providers
-        self.providers = properties.get('providers')
-        if self.providers is not None:
-            self.providers = [Provider.from_dict(d) for d in self.providers]
+    @property
+    def description(self):
+        """Get or set the item's description
 
-        # Instrument
-        self.platform = properties.get('platform')
-        self.instruments = properties.get('instruments')
-        self.constellation = properties.get('constellation')
-        self.mission = properties.get('mission')
+        Returns:
+            str: Detailed description of the item
+        """
+        return self.properties.get('description')
 
-        # Metadata
-        self.created = properties.get('created')
-        if self.created is not None:
-            self.created = dateutil.parser.parse(self.created)
-        self.updated = properties.get('updated')
-        if self.updated is not None:
-            self.updated = dateutil.parser.parse(self.updated)
+    @description.setter
+    def description(self, v):
+        self.properties['description'] = v
+
+    # Date and Time Range
+    @property
+    def start_datetime(self):
+        """Get or set the item's start_datetime. All datetime attributes have
+        setters that can take either a string or a datetime, but always stores
+        the attribute as a string
+
+        Returns:
+            datetime: Start date and time for the item
+        """
+        return self.get_datetime('start_datetime')
+
+    @start_datetime.setter
+    def start_datetime(self, v):
+        self.set_datetime(v, 'start_datetime')
+
+    @property
+    def end_datetime(self):
+        """Get or set the item's end_datetime. All datetime attributes have
+        setters that can take either a string or a datetime, but always stores
+        the attribute as a string
+
+        Returns:
+            datetime: End date and time for the item
+        """
+        return self.get_datetime('end_datetime')
+
+    @end_datetime.setter
+    def end_datetime(self, v):
+        self.set_datetime(v, 'end_datetime')
+
+    # License
+    @property
+    def license(self):
+        """Get or set the current license
+
+        Returns:
+            str: Item's license(s), either SPDX identifier of 'various'
+        """
+        return self.properties.get('license')
+
+    @license.setter
+    def license(self, v):
+        self.properties['license'] = v
+
+    # Providers
+    @property
+    def providers(self):
+        """Get or set a list of the item's providers. The setter can take either
+        a Provider object or a dict but always stores each provider as a dict
+
+        Returns:
+            [Provider]: List of organizations that captured or processed the data,
+            encoded as Provider objects
+        """
+        providers = self.properties.get('providers')
+        if providers is not None:
+            providers = [Provider.from_dict(d) for d in providers]
+
+        return providers
+
+    @providers.setter
+    def providers(self, v):
+        if v is None:
+            self.properties['providers'] = v
+        else:
+            self.properties['providers'] = [
+                p.to_dict() if isinstance(p, Provider) else p for p in v
+            ]
+
+    # Instrument
+    @property
+    def platform(self):
+        """Get or set the item's platform attribute
+
+        Returns:
+            str: Unique name of the specific platform to which the instrument
+            is attached
+        """
+        return self.properties.get('platform')
+
+    @platform.setter
+    def platform(self, v):
+        self.properties['platform'] = v
+
+    @property
+    def instruments(self):
+        """Get or set the names of the instruments used
+
+        Returns:
+            [str]: Name(s) of instrument(s) used
+        """
+        return self.properties.get('instruments')
+
+    @instruments.setter
+    def instruments(self, v):
+        self.properties['instruments'] = v
+
+    @property
+    def constellation(self):
+        """Get or set the name of the constellation associate with an item
+
+        Returns:
+            str: Name of the constellation to which the platform belongs
+        """
+        return self.properties.get('constellation')
+
+    @constellation.setter
+    def constellation(self, v):
+        self.properties['constellation'] = v
+
+    @property
+    def mission(self):
+        """Get or set the name of the mission associated with an item
+
+        Returns:
+            str: Name of the mission in which data are collected
+        """
+        return self.properties.get('mission')
+
+    @mission.setter
+    def mission(self, v):
+        self.properties['mission'] = v
+
+    # Metadata
+    @property
+    def created(self):
+        """Get or set the metadata file's creation date. All datetime attributes have
+        setters that can take either a string or a datetime, but always stores
+        the attribute as a string
+
+        Returns:
+            datetime: Creation date and time of the metadata file
+        """
+        return self.get_datetime('created')
+
+    @created.setter
+    def created(self, v):
+        self.set_datetime(v, 'created')
+
+    @property
+    def updated(self):
+        """Get or set the metadata file's creation date. All datetime attributes have
+        setters that can take either a string or a datetime, but always stores
+        the attribute as a string
+
+        Returns:
+            datetime: Date and time that the metadata file was most recently
+                updated
+        """
+        return self.get_datetime('updated')
+
+    @updated.setter
+    def updated(self, v):
+        self.set_datetime(v, 'updated')
 
     @property
     def time_range(self):
-        """Get the start and end times for the item
+        """Get the start and end times for the item as a PySTAC temporal extent. Sets
+        the start_time and end_time attributes within properties
 
         Returns:
             TemporalExtent: PySTAC Temporal Extent object with the start and end
@@ -489,24 +647,35 @@ class CommonMetadata:
         """
         return TemporalExtent([[self.start_datetime, self.end_datetime]])
 
+    @time_range.setter
+    def time_range(self, v):
+        """Set the start_time and end_time attributes from a PySTAC TemporalExtent
+
+        Args:
+            v (TemporalExtent): The temporal extent of the item
+        """
+        if not isinstance(v, TemporalExtent):
+            raise Exception(
+                'Item CommonMetadata time range must be sent with a TemporalExtent, got {}'.format(
+                    type(v)))
+
+        start_datetime, end_datetime = v.intervals[0]
+        self.set_datetime(start_datetime, 'start_datetime')
+        self.set_datetime(end_datetime, 'end_datetime')
+
     @staticmethod
     def from_dict(d):
         return CommonMetadata(d)
 
-    def to_dict(self):
-        d = {}
-        attributes = [
-            'title', 'description', 'start_datetime', 'end_datetime', 'license', 'providers',
-            'platform', 'instruments', 'constellation', 'mission', 'created', 'updated'
-        ]
-        for a in attributes:
-            x = self.__getattribute__(a)
-            if x is not None:
-                if a == 'providers':
-                    d[a] = [y.to_dict() for y in x]
-                elif isinstance(x, datetime):
-                    d[a] = x.strftime('%Y-%m-%dT%H:%M:%S.') + x.strftime('%f')[0:3] + 'Z'
-                else:
-                    d[a] = x
+    def get_datetime(self, key):
+        datetime_var = copy(self.properties.get(key))
+        if not isinstance(datetime_var, datetime) and datetime_var:
+            datetime_var = dateutil.parser.parse(datetime_var)
 
-        return d
+        return datetime_var
+
+    def set_datetime(self, v, key):
+        if isinstance(v, datetime):
+            self.properties[key] = v.strftime('%Y-%m-%dT%H:%M:%S.') + v.strftime('%f')[0:3] + 'Z'
+        else:
+            self.properties[key] = v

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -268,22 +268,6 @@ class Item(STACObject):
         """
         return CommonMetadata(self.properties)
 
-    def set_common_metadata(self, common_metadata, override=False):
-        """Update common metadata properties within an item from a CommonMetadata
-        object
-
-        Args:
-            common_metadata (CommonMetadat): The CommonMetadata object which
-                will define fields in the item's properties
-            override (bool, optional): Whether or not to override . Defaults to False.
-        """
-        for k, v in common_metadata.properties.items():
-            if k in self.properties:
-                if override:
-                    self.properties[k] = v
-            else:
-                self.properties[k] = v
-
 
 class Asset:
     """An object that contains a link to data associated with the Item that can be
@@ -632,4 +616,4 @@ class CommonMetadata:
 
     @updated.setter
     def updated(self, v):
-        self.properties['end_datetime'] = v
+        self.properties['updated'] = v

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -147,3 +147,36 @@ def datetime_to_str(dt):
         timestamp = '{}Z'.format(timestamp[:-len(zulu)])
 
     return timestamp
+
+def geometry_to_bbox(geometry):
+    """Extract the bounding box from a geojson geometry
+
+    Args:
+        geometry (dict): GeoJSON geometry dict
+
+    Returns:
+        list: Bounding box of geojson geometry, formatted according to:
+        https://tools.ietf.org/html/rfc7946#section-5
+    """
+    coords = geometry['coordinates']
+    
+    lats = []
+    lons = []
+
+    def extract_coords(coords):    
+        for x in coords:
+            if isinstance(x[0], list):
+                extract_coords(x)
+            else:
+                lat, lon = x
+                lats.append(lat)
+                lons.append(lon)
+
+    extract_coords(coords)
+
+    lons.sort()
+    lats.sort()
+
+    bbox = [lats[0], lons[0], lats[-1], lons[-1]]
+    
+    return bbox

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -2,6 +2,7 @@ import os
 import posixpath
 from urllib.parse import (urlparse, ParseResult as URLParseResult)
 from datetime import timezone
+import dateutil.parser
 
 # Allow for modifying the path library for testability
 # (i.e. testing Windows path manipulation on non-Windows systems)
@@ -147,6 +148,10 @@ def datetime_to_str(dt):
         timestamp = '{}Z'.format(timestamp[:-len(zulu)])
 
     return timestamp
+
+
+def str_to_datetime(s):
+    return dateutil.parser.parse(s)
 
 
 def geometry_to_bbox(geometry):

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -148,6 +148,7 @@ def datetime_to_str(dt):
 
     return timestamp
 
+
 def geometry_to_bbox(geometry):
     """Extract the bounding box from a geojson geometry
 
@@ -159,11 +160,11 @@ def geometry_to_bbox(geometry):
         https://tools.ietf.org/html/rfc7946#section-5
     """
     coords = geometry['coordinates']
-    
+
     lats = []
     lons = []
 
-    def extract_coords(coords):    
+    def extract_coords(coords):
         for x in coords:
             if isinstance(x[0], list):
                 extract_coords(x)
@@ -178,5 +179,5 @@ def geometry_to_bbox(geometry):
     lats.sort()
 
     bbox = [lats[0], lons[0], lats[-1], lons[-1]]
-    
+
     return bbox

--- a/tests/data-files/eo/eo-landsat-example.json
+++ b/tests/data-files/eo/eo-landsat-example.json
@@ -43,89 +43,73 @@
         "collection": "landsat-8-l1",
         "datetime": "2018-10-01T01:08:32.033Z",
         "eo:cloud_cover": 78,
-        "eo:sun_azimuth": 168.8989761,
-        "eo:sun_elevation": 26.32596431,
         "landsat:path": 107,
         "landsat:row": 18,
         "eo:gsd": 30,
-        "eo:platform": "landsat-8",
-        "eo:instrument": "oli_tirs",
-        "eo:off_nadir": 0,
         "eo:bands": [
             {
                 "name": "B1",
                 "common_name": "coastal",
-                "gsd": 30,
                 "center_wavelength": 0.44,
                 "full_width_half_max": 0.02
             },
             {
                 "name": "B2",
                 "common_name": "blue",
-                "gsd": 30,
                 "center_wavelength": 0.48,
                 "full_width_half_max": 0.06
             },
             {
                 "name": "B3",
                 "common_name": "green",
-                "gsd": 30,
                 "center_wavelength": 0.56,
                 "full_width_half_max": 0.06
             },
             {
                 "name": "B4",
                 "common_name": "red",
-                "gsd": 30,
                 "center_wavelength": 0.65,
                 "full_width_half_max": 0.04
             },
             {
                 "name": "B5",
                 "common_name": "nir",
-                "gsd": 30,
                 "center_wavelength": 0.86,
                 "full_width_half_max": 0.03
             },
             {
                 "name": "B6",
                 "common_name": "swir16",
-                "gsd": 30,
                 "center_wavelength": 1.6,
                 "full_width_half_max": 0.08
             },
             {
                 "name": "B7",
                 "common_name": "swir22",
-                "gsd": 30,
                 "center_wavelength": 2.2,
                 "full_width_half_max": 0.2
             },
             {
                 "name": "B8",
                 "common_name": "pan",
-                "gsd": 15,
                 "center_wavelength": 0.59,
                 "full_width_half_max": 0.18
             },
             {
                 "name": "B9",
                 "common_name": "cirrus",
-                "gsd": 30,
                 "center_wavelength": 1.37,
                 "full_width_half_max": 0.02
             },
             {
                 "name": "B10",
                 "common_name": "lwir11",
-                "gsd": 100,
                 "center_wavelength": 10.9,
                 "full_width_half_max": 0.8
             },
             {
                 "name": "B11",
                 "common_name": "lwir12",
-                "gsd": 100,
                 "center_wavelength": 12,
                 "full_width_half_max": 1
             }

--- a/tests/data-files/examples/0.9.0/extensions/asset/examples/example-landsat8.json
+++ b/tests/data-files/examples/0.9.0/extensions/asset/examples/example-landsat8.json
@@ -244,7 +244,7 @@
             ],
             "title": "LWIR Band (B11)",
             "description": "Long-wave IR Band at 12um (B11) Top Of the Atmosphere"
-        },
-        "links": []
-    }
+        }
+    },
+    "links": []
 }

--- a/tests/data-files/examples/0.9.0/extensions/commons/examples/landsat-item.json
+++ b/tests/data-files/examples/0.9.0/extensions/commons/examples/landsat-item.json
@@ -160,6 +160,7 @@
             "type": "image/jpeg"
         },
         "index": {
+            "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/index.html",
             "type": "text/html",
             "title": "HTML index page"
         }

--- a/tests/data-files/examples/0.9.0/item-spec/examples/CBERS_4_MUX_20181029_177_106_L4.json
+++ b/tests/data-files/examples/0.9.0/item-spec/examples/CBERS_4_MUX_20181029_177_106_L4.json
@@ -44,6 +44,33 @@
         -4.731829
     ],
     "properties": {
+        "eo:gsd": 20,
+        "eo:bands": [
+            {
+                "name":"B5",
+                "common_name": "blue",
+                "center_wavelength": 0.485,
+                "full_width_half_max": 0.07
+            },
+            {
+                "name":"B6",
+                "common_name": "green",
+                "center_wavelength": 0.555,
+                "full_width_half_max": 0.07
+            },
+            {
+                "name":"B7",
+                "common_name": "red",
+                "center_wavelength": 0.66,
+                "full_width_half_max": 0.06
+            },
+            {
+                "name":"B8",
+                "common_name": "NIR",
+                "center_wavelength": 0.83,
+                "full_width_half_max": 0.12
+            }
+        ],
         "datetime": "2018-10-29T14:24:54Z",
         "view:sun_azimuth": 111.113,
         "view:sun_elevation": 65.8018,
@@ -78,34 +105,6 @@
             "type": "text/xml",
             "roles": [
                 "metadata"
-            ]
-        },
-        "B5": {
-            "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND5.tif",
-            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-            "eo:bands": [
-                0
-            ]
-        },
-        "B6": {
-            "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND6.tif",
-            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-            "eo:bands": [
-                1
-            ]
-        },
-        "B7": {
-            "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND7.tif",
-            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-            "eo:bands": [
-                2
-            ]
-        },
-        "B8": {
-            "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND8.tif",
-            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-            "eo:bands": [
-                3
             ]
         }
     }

--- a/tests/data-files/examples/0.9.0/item-spec/examples/digitalglobe-sample.json
+++ b/tests/data-files/examples/0.9.0/item-spec/examples/digitalglobe-sample.json
@@ -8,6 +8,11 @@
     ],
     "id": "103001004B316600_P002_MUL",
     "type": "Feature",
+    "bbox": [
+        -105.161151214, 
+        39.0436821016, 
+        -104.947574355, 
+        39.1750024943],
     "geometry": {
         "type": "Polygon",
         "coordinates": [
@@ -81,6 +86,7 @@
         "platform": "worldview02",
         "view:sun_elevation": 33.4,
         "eo:gsd": 2.047,
+        "eo:bands": [],
         "proj:epsg": null,
         "dg:catalog_id": "103001004B316600",
         "dg:soli": "056823192",
@@ -91,10 +97,8 @@
         "datetime": "2015-11-09T18:04:46.000Z"
     },
     "collection": "dg_worldview02",
-    "links": [
-        {
-            "rel": "self",
-            "href": "https://s3.amazonaws.com/digitalglobe-catalog-spec/collections/dg_worldview02_lv1b/103001004B316600_P002_MUL"
-        }
-    ]
+    "links": [{
+        "rel": "self",
+        "href": "https://s3.amazonaws.com/digitalglobe-catalog-spec/collections/dg_worldview02_lv1b/103001004B316600_P002_MUL"
+    }]
 }

--- a/tests/data-files/examples/0.9.0/item-spec/examples/landsat8-sample.json
+++ b/tests/data-files/examples/0.9.0/item-spec/examples/landsat8-sample.json
@@ -44,6 +44,85 @@
         "datetime": "2014-06-02T09:22:02Z",
         "collection": "L1T",
         "eo:gsd": 30.0,
+        "eo:bands": [
+            {
+                "name": "B1",
+                "common_name": "coastal",
+                "gsd": 30,
+                "center_wavelength": 0.44,
+                "full_width_half_max": 0.02
+            },
+            {
+                "name": "B2",
+                "common_name": "blue",
+                "gsd": 30,
+                "center_wavelength": 0.48,
+                "full_width_half_max": 0.06
+            },
+            {
+                "name": "B3",
+                "common_name": "green",
+                "gsd": 30,
+                "center_wavelength": 0.56,
+                "full_width_half_max": 0.06
+            },
+            {
+                "name": "B4",
+                "common_name": "red",
+                "gsd": 30,
+                "center_wavelength": 0.65,
+                "full_width_half_max": 0.04
+            },
+            {
+                "name": "B5",
+                "common_name": "nir",
+                "gsd": 30,
+                "center_wavelength": 0.86,
+                "full_width_half_max": 0.03
+            },
+            {
+                "name": "B6",
+                "common_name": "swir16",
+                "gsd": 30,
+                "center_wavelength": 1.6,
+                "full_width_half_max": 0.08
+            },
+            {
+                "name": "B7",
+                "common_name": "swir22",
+                "gsd": 30,
+                "center_wavelength": 2.2,
+                "full_width_half_max": 0.2
+            },
+            {
+                "name": "B8",
+                "common_name": "pan",
+                "gsd": 15,
+                "center_wavelength": 0.59,
+                "full_width_half_max": 0.18
+            },
+            {
+                "name": "B9",
+                "common_name": "cirrus",
+                "gsd": 30,
+                "center_wavelength": 1.37,
+                "full_width_half_max": 0.02
+            },
+            {
+                "name": "B10",
+                "common_name": "lwir11",
+                "gsd": 100,
+                "center_wavelength": 10.9,
+                "full_width_half_max": 0.8
+            },
+            {
+                "name": "B11",
+                "common_name": "lwir12",
+                "gsd": 100,
+                "center_wavelength": 12,
+                "full_width_half_max": 1
+            }
+        ],
         "eo:cloud_cover": 10,
         "view:off_nadir": 0.0,
         "view:azimuth": 0.0,

--- a/tests/data-files/examples/0.9.0/item-spec/examples/planet-sample.json
+++ b/tests/data-files/examples/0.9.0/item-spec/examples/planet-sample.json
@@ -69,6 +69,7 @@
         "datetime": "2017-11-10T12:10:30.535417Z",
         "eo:cloud_cover": 23,
         "eo:gsd": 3.7,
+        "eo:bands": [],
         "view:sun_azimuth": 101.8,
         "view:sun_elevation": 58.8,
         "view:off_nadir": 1,

--- a/tests/data-files/get_examples.py
+++ b/tests/data-files/get_examples.py
@@ -3,7 +3,6 @@ Script to download the examples from the stac-spec repository.
 This is used when new version come out to look for updated examples
 """
 import os
-import shutil
 import argparse
 import json
 from tempfile import TemporaryDirectory
@@ -12,7 +11,7 @@ from urllib.error import HTTPError
 
 from pystac import (STAC_VERSION, STAC_IO)
 from pystac.serialization import identify_stac_object, STACObjectType
-import tests # Sets up STAC_IO
+
 
 def remove_bad_collection(js):
     links = js.get('links')
@@ -32,10 +31,13 @@ def remove_bad_collection(js):
         js['links'] = filtered_links
     return js
 
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Process some integers.')
-    parser.add_argument('previous_version', metavar='PREVIOUS_VERSION',
-                        help='The previous STAC_VERSION that examples have already been pulled from.')
+    parser.add_argument(
+        'previous_version',
+        metavar='PREVIOUS_VERSION',
+        help='The previous STAC_VERSION that examples have already been pulled from.')
 
     args = parser.parse_args()
 
@@ -45,15 +47,11 @@ if __name__ == '__main__':
     examples_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'examples'))
 
     with TemporaryDirectory() as tmp_dir:
-        call(['git', 'clone',
-              '--depth', '1',
-              '--branch', stac_spec_tag,
-              stac_repo,
-              tmp_dir])
+        call(['git', 'clone', '--depth', '1', '--branch', stac_spec_tag, stac_repo, tmp_dir])
 
         example_dirs = []
         for root, _, _ in os.walk(tmp_dir):
-                example_dirs.append(os.path.join(root))
+            example_dirs.append(os.path.join(root))
 
         example_csv_lines = []
 
@@ -71,9 +69,9 @@ if __name__ == '__main__':
                             example_version = js.get('stac_version')
                         if example_version is not None and \
                            example_version > args.previous_version:
-                            relpath = '{}/{}'.format(STAC_VERSION, path.replace('{}/'.format(tmp_dir), ''))
-                            target_path = os.path.join(examples_dir,
-                                                       relpath)
+                            relpath = '{}/{}'.format(STAC_VERSION,
+                                                     path.replace('{}/'.format(tmp_dir), ''))
+                            target_path = os.path.join(examples_dir, relpath)
 
                             print('Creating example at {}'.format(target_path))
 
@@ -92,15 +90,14 @@ if __name__ == '__main__':
                                 f.write(json.dumps(js, indent=4))
 
                             # Add info to the new example-info.csv lines
-                            example_csv_lines.append([relpath,
-                                                      info.object_type,
-                                                      example_version,
-                                                      '|'.join(info.common_extensions),
-                                                      '|'.join(info.custom_extensions)])
+                            example_csv_lines.append([
+                                relpath, info.object_type, example_version,
+                                '|'.join(info.common_extensions), '|'.join(info.custom_extensions)
+                            ])
 
         # Write the new example-info.csv lines into a temp file for inspection
         with open(os.path.join(examples_dir, 'examples-info-NEW.csv'), 'w') as f:
-            txt = '\n'.join(map(lambda line: '"{}"'.format(line),
-                                map(lambda row: '","'.join(row),
-                                    example_csv_lines)))
+            txt = '\n'.join(
+                map(lambda line: '"{}"'.format(line),
+                    map(lambda row: '","'.join(row), example_csv_lines)))
             f.write(txt)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -3,6 +3,7 @@ import json
 
 from pystac import Asset, Item, Provider
 from pystac.item import CommonMetadata
+from pystac.utils import str_to_datetime
 from tests.utils import (TestCases, test_to_from_dict)
 from datetime import datetime
 
@@ -89,49 +90,167 @@ class CommonMetadataTest(unittest.TestCase):
         self.assertDictEqual(before, self.ITEM_1.to_dict())
         self.assertIsNone(common_metadata.providers)
 
-    def test_set_common_metadata(self):
-        common_metadata = self.ITEM_2.common_metadata
+    def test_common_metadata_start_datetime(self):
+        x = self.ITEM_1.clone()
+        start_datetime_str = "2018-01-01T13:21:30Z"
+        start_datetime_dt = str_to_datetime(start_datetime_str)
+        example_datetime_str = "2020-01-01T00:00:00"
+        example_datetime_dt = str_to_datetime(example_datetime_str)
 
-        for provider in common_metadata.providers:
-            self.assertIsInstance(provider, Provider)
-        self.assertEqual(common_metadata.platform, 'coolsat2')
+        self.assertEqual(x.common_metadata.start_datetime, start_datetime_dt)
+        self.assertEqual(x.properties['start_datetime'], start_datetime_str)
 
-        example_cm = CommonMetadata(self.EXAMPLE_CM_DICT)
-        self.assertIsInstance(example_cm.start_datetime, datetime)
-        self.assertIsInstance(example_cm.providers[0], Provider)
+        x.common_metadata.start_datetime = example_datetime_str
 
-        item_2_copy = self.ITEM_2.clone()
+        self.assertEqual(x.common_metadata.start_datetime, example_datetime_dt)
+        self.assertEqual(x.properties['start_datetime'], example_datetime_str)
 
-        item_2_copy.set_common_metadata(example_cm)
-        self.assertNotEqual(self.EXAMPLE_CM_DICT['platform'], item_2_copy.properties['platform'])
-        self.assertEqual(item_2_copy.properties['platform'], self.ITEM_2.properties['platform'])
-        item_2_copy.set_common_metadata(example_cm, override=True)
+    def test_common_metadata_end_datetime(self):
+        x = self.ITEM_1.clone()
+        end_datetime_str = "2018-01-01T13:31:30Z"
+        end_datetime_dt = str_to_datetime(end_datetime_str)
+        example_datetime_str = "2020-01-01T00:00:00"
+        example_datetime_dt = str_to_datetime(example_datetime_str)
 
-        self.assertEqual(self.EXAMPLE_CM_DICT['platform'], item_2_copy.properties['platform'])
-        self.assertNotEqual(item_2_copy.properties['platform'], self.ITEM_2.properties['platform'])
-        self.assertIsInstance(item_2_copy.properties['start_datetime'], str)
-        self.assertEqual(item_2_copy.properties['start_datetime'],
-                         self.EXAMPLE_CM_DICT['start_datetime'])
-        self.assertEqual(item_2_copy.properties['platform'], self.EXAMPLE_CM_DICT['platform'])
-        for i, provider in enumerate(item_2_copy.properties['providers']):
-            self.assertDictEqual(provider, self.EXAMPLE_CM_DICT['providers'][i])
+        self.assertEqual(x.common_metadata.end_datetime, end_datetime_dt)
+        self.assertEqual(x.properties['end_datetime'], end_datetime_str)
 
-    def test_common_metadata_getter_setters(self):
-        item_2 = self.ITEM_2.clone()
-        self.assertIsInstance(item_2.common_metadata.updated, datetime)
-        self.assertIsInstance(item_2.properties['updated'], str)
+        x.common_metadata.end_datetime = example_datetime_str
 
-        self.assertIsInstance(item_2.common_metadata.providers[0], Provider)
-        self.assertIsInstance(item_2.properties['providers'][0], dict)
+        self.assertEqual(x.common_metadata.end_datetime, example_datetime_dt)
+        self.assertEqual(x.properties['end_datetime'], example_datetime_str)
 
-        sample_license = 'sample license'
-        item_2.common_metadata.license = sample_license
-        self.assertEqual(item_2.properties['license'], sample_license)
+    def test_common_metadata_created(self):
+        x = self.ITEM_2.clone()
+        created_str = "2016-05-04T00:00:01Z"
+        created_dt = str_to_datetime(created_str)
+        example_datetime_str = "2020-01-01T00:00:00"
+        example_datetime_dt = str_to_datetime(example_datetime_str)
 
-        sample_start = '2020-05-21T16:42:24.896Z'
-        sample_end = '2020-05-22T16:42:24.896Z'
+        self.assertEqual(x.common_metadata.created, created_dt)
+        self.assertEqual(x.properties['created'], created_str)
 
-        item_2.common_metadata.start_datetime = sample_start
-        item_2.common_metadata.end_datetime = sample_end
-        self.assertIsInstance(item_2.common_metadata.start_datetime, datetime)
-        self.assertEqual(item_2.properties['start_datetime'], sample_start)
+        x.common_metadata.created = example_datetime_str
+
+        self.assertEqual(x.common_metadata.created, example_datetime_dt)
+        self.assertEqual(x.properties['created'], example_datetime_str)
+
+    def test_common_metadata_updated(self):
+        x = self.ITEM_2.clone()
+        updated_str = "2017-01-01T00:30:55Z"
+        updated_dt = str_to_datetime(updated_str)
+        example_datetime_str = "2020-01-01T00:00:00"
+        example_datetime_dt = str_to_datetime(example_datetime_str)
+
+        self.assertEqual(x.common_metadata.updated, updated_dt)
+        self.assertEqual(x.properties['updated'], updated_str)
+
+        x.common_metadata.updated = example_datetime_str
+
+        self.assertEqual(x.common_metadata.updated, example_datetime_dt)
+        self.assertEqual(x.properties['updated'], example_datetime_str)
+
+    def test_common_metadata_providers(self):
+        x = self.ITEM_2.clone()
+
+        providers_dict_list = [{
+            "name": "CoolSat",
+            "roles": ["producer", "licensor"],
+            "url": "https://cool-sat.com/"
+        }]
+        providers_object_list = [Provider.from_dict(d) for d in providers_dict_list]
+
+        example_providers_dict_list = [{
+            "name": "ExampleProvider_1",
+            "roles": ["example_role_1", "example_role_2"],
+            "url": "https://exampleprovider1.com/"
+        }, {
+            "name": "ExampleProvider_2",
+            "roles": ["example_role_1", "example_role_2"],
+            "url": "https://exampleprovider2.com/"
+        }]
+        example_providers_object_list = [Provider.from_dict(d) for d in example_providers_dict_list]
+
+        for i in range(len(x.common_metadata.providers)):
+            p1 = x.common_metadata.providers[i]
+            p2 = providers_object_list[i]
+            self.assertIsInstance(p1, Provider)
+            self.assertIsInstance(p2, Provider)
+            self.assertDictEqual(p1.to_dict(), p2.to_dict())
+
+            pd1 = x.properties['providers'][i]
+            pd2 = providers_dict_list[i]
+            self.assertIsInstance(pd1, dict)
+            self.assertIsInstance(pd2, dict)
+            self.assertDictEqual(pd1, pd2)
+
+        x.common_metadata.providers = example_providers_dict_list
+
+        for i in range(len(x.common_metadata.providers)):
+            p1 = x.common_metadata.providers[i]
+            p2 = example_providers_object_list[i]
+            self.assertIsInstance(p1, Provider)
+            self.assertIsInstance(p2, Provider)
+            self.assertDictEqual(p1.to_dict(), p2.to_dict())
+
+            pd1 = x.properties['providers'][i]
+            pd2 = example_providers_dict_list[i]
+            self.assertIsInstance(pd1, dict)
+            self.assertIsInstance(pd2, dict)
+            self.assertDictEqual(pd1, pd2)
+
+    def test_common_metadata_basics(self):
+        x = self.ITEM_2.clone()
+
+        # Title
+        title = "A CS3 item"
+        example_title = "example title"
+        self.assertEqual(x.common_metadata.title, title)
+        x.common_metadata.title = example_title
+        self.assertEqual(x.common_metadata.title, example_title)
+        self.assertEqual(x.properties['title'], example_title)
+
+        # Description
+        example_description = "example description"
+        self.assertIsNone(x.common_metadata.description)
+        x.common_metadata.description = example_description
+        self.assertEqual(x.common_metadata.description, example_description)
+        self.assertEqual(x.properties['description'], example_description)
+
+        # License
+        license = "PDDL-1.0"
+        example_license = "example license"
+        self.assertEqual(x.common_metadata.license, license)
+        x.common_metadata.license = example_license
+        self.assertEqual(x.common_metadata.license, example_license)
+        self.assertEqual(x.properties['license'], example_license)
+
+        # Platform
+        platform = "coolsat2"
+        example_platform = "example_platform"
+        self.assertEqual(x.common_metadata.platform, platform)
+        x.common_metadata.platform = example_platform
+        self.assertEqual(x.common_metadata.platform, example_platform)
+        self.assertEqual(x.properties['platform'], example_platform)
+
+        # Instruments
+        instruments = ["cool_sensor_v1"]
+        example_instruments = ["example instrument 1", "example instrument 2"]
+        self.assertListEqual(x.common_metadata.instruments, instruments)
+        x.common_metadata.instruments = example_instruments
+        self.assertListEqual(x.common_metadata.instruments, example_instruments)
+        self.assertListEqual(x.properties['instruments'], example_instruments)
+
+        # Constellation
+        example_constellation = "example constellation"
+        self.assertIsNone(x.common_metadata.constellation)
+        x.common_metadata.constellation = example_constellation
+        self.assertEqual(x.common_metadata.constellation, example_constellation)
+        self.assertEqual(x.properties['constellation'], example_constellation)
+
+        # Mission
+        example_mission = "example mission"
+        self.assertIsNone(x.common_metadata.mission)
+        x.common_metadata.mission = example_mission
+        self.assertEqual(x.common_metadata.mission, example_mission)
+        self.assertEqual(x.properties['mission'], example_mission)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,8 +1,10 @@
 import unittest
 import json
 
-from pystac import Asset, Item
+from pystac import Asset, Item, TemporalExtent, Provider
+from pystac.item import CommonMetadata
 from tests.utils import (TestCases, test_to_from_dict)
+from datetime import datetime
 
 
 class ItemTest(unittest.TestCase):
@@ -50,3 +52,78 @@ class ItemTest(unittest.TestCase):
         assert len(item.assets) > 0
         for asset_key in item.assets:
             self.assertEqual(item.assets[asset_key].owner, item)
+
+
+class CommonMetadataTest(unittest.TestCase):
+    def setUp(self):
+        self.URI_1 = TestCases.get_path(
+            'data-files/examples/0.9.0/item-spec/examples/datetimerange.json')
+        self.ITEM_1 = Item.from_file(self.URI_1)
+
+        self.URI_2 = TestCases.get_path(
+            'data-files/examples/0.9.0/item-spec/examples/sample-full.json')
+        self.ITEM_2 = Item.from_file(self.URI_2)
+
+        self.EXAMPLE_CM_DICT = {
+            'start_datetime':
+            '2020-05-21T16:42:24.896Z',
+            'platform':
+            'example platform',
+            'providers': [{
+                'name': 'example provider',
+                'roles': ['example roll'],
+                'url': 'https://example-provider.com/'
+            }]
+        }
+
+    def test_datetimes(self):
+        # save dict of original item to check that `common_metadata`
+        # method doesn't mutate self.item_1
+        before = self.ITEM_1.clone().to_dict()
+        start_datetime_str = self.ITEM_1.properties['start_datetime']
+        end_datetime_str = self.ITEM_1.properties['end_datetime']
+        self.assertIsInstance(start_datetime_str, str)
+
+        common_metadata = self.ITEM_1.common_metadata
+        self.assertIsInstance(common_metadata, CommonMetadata)
+        self.assertIsInstance(common_metadata.start_datetime, datetime)
+
+        temp_ext = common_metadata.time_range
+        self.assertIsInstance(temp_ext, TemporalExtent)
+
+        test_dict = {'interval': [[start_datetime_str, end_datetime_str]]}
+        self.assertDictEqual(temp_ext.to_dict(), test_dict)
+
+        self.assertDictEqual(before, self.ITEM_1.to_dict())
+
+        self.assertIsNone(common_metadata.providers)
+
+        common_metadata_dict = common_metadata.to_dict()
+        common_metadata_2 = CommonMetadata.from_dict(common_metadata_dict)
+        self.assertEqual(common_metadata.start_datetime, common_metadata_2.start_datetime)
+
+    def test_set_common_metadata(self):
+        common_metadata = self.ITEM_2.common_metadata
+
+        for provider in common_metadata.providers:
+            self.assertIsInstance(provider, Provider)
+        self.assertEqual(common_metadata.platform, 'coolsat2')
+
+        example_cm = CommonMetadata.from_dict(self.EXAMPLE_CM_DICT)
+        self.assertIsInstance(example_cm.start_datetime, datetime)
+        self.assertIsInstance(example_cm.providers[0], Provider)
+
+        item_2_copy = self.ITEM_2.clone()
+        item_2_copy.set_common_metadata(example_cm)
+        self.assertNotEqual(self.EXAMPLE_CM_DICT['platform'], item_2_copy.properties['platform'])
+        self.assertEqual(item_2_copy.properties['platform'], self.ITEM_2.properties['platform'])
+
+        item_2_copy.set_common_metadata(example_cm, override=True)
+        self.assertEqual(self.EXAMPLE_CM_DICT['platform'], item_2_copy.properties['platform'])
+        self.assertNotEqual(item_2_copy.properties['platform'], self.ITEM_2.properties['platform'])
+        self.assertIsInstance(item_2_copy.properties['start_datetime'], str)
+        self.assertEqual(item_2_copy.properties['start_datetime'],
+                         self.EXAMPLE_CM_DICT['start_datetime'])
+        self.assertEqual(item_2_copy.properties['platform'], self.EXAMPLE_CM_DICT['platform'])
+        for i, provider in enumerate(item_2_copy.properties['providers']):
+            self.assertDictEqual(provider, self.EXAMPLE_CM_DICT['providers'][i])


### PR DESCRIPTION
New version of #96, with cleaned up commit history

----
This PR updates pystac to comply with STAC version 0.9. It does not add new extensions but updates the existing code (as well as unit test example JSON files to work with the newest version of STAC).

Individual changes:
- updates unit test example data files so that they comply with 0.9
- adds `CommonMetadata` class which stores all common fields present in item properties that are not actual attributes of items. 
- removes specific properties from EOItems
- removes version attribute from Collections
- Changes docstring for license aregument in collections
- removes GSD and accuracy for Bands objects
- adds rolls to asset definition
- adds utility function to get bbox from geojson without needing shapely. Could be used if we want to allow users to construct an item without needing to provide the bbox (though geometry would still be required)
- changes stac_object from_file method to only try setting a root_link if the item has one. This was failing on the unit tests when I was trying to read an item (with no root) in from a file

Addresses many of the items in #96 