### PR TITLE
fix root link bug

### DIFF
--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -408,9 +408,10 @@ class STACObject(LinkMixin, ABC):
 
         # If this is a root catalog, set the root to the catalog instance.
         root_link = o.get_root_link()
-        if not root_link.is_resolved():
-            if root_link.get_absolute_href() == href:
-                o.set_root(o, link_type=root_link.link_type)
+        if root_link is not None:
+            if not root_link.is_resolved():
+                if root_link.get_absolute_href() == href:
+                    o.set_root(o, link_type=root_link.link_type)
         return o
 
     @classmethod

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -50,3 +50,12 @@ class ItemTest(unittest.TestCase):
         assert len(item.assets) > 0
         for asset_key in item.assets:
             self.assertEqual(item.assets[asset_key].owner, item)
+
+    def test_self_contained_item(self):
+        m = TestCases.get_path('data-files/itemcollections/sample-item-collection.json')
+        with open(m) as f:
+            item_dict = json.load(f)['features'][0]
+        item_dict['links'] = [l for l in item_dict['links'] if l['rel'] == 'self']
+        item = Item.from_dict(item_dict)
+        self.assertIsInstance(item, Item)
+        self.assertEqual(len(item.links), 1)


### PR DESCRIPTION
Currently PySTAC throws an error when trying to read an Item from a dict if the item does not have a root link. While that case is not STAC compliant, it still makes the most sense for this not to fail. Necessary to pass item unit tests.