### PR TITLE
fix __repr__ bug

### DIFF
--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -84,7 +84,7 @@ class EOItemExt(ItemExtension):
         self.item.properties['eo:cloud_cover'] = v
 
     def __repr__(self):
-        return '<EOItemExt Item id={}>'.format(self.id)
+        return '<EOItemExt Item id={}>'.format(self.item.id)
 
     def get_asset_bands(self, asset):
         """Gets the bands for the given asset.


### PR DESCRIPTION
This surfaced when trying to print out an eoextension obj:

tries to reference the ext id rather than the underlying item