### PR TITLE
Add primary Git branches to CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,10 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - develop
+      - master
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## PySTAC
-![Build Status](https://github.com/azavea/pystac/workflows/CI/badge.svg)
+![Build Status](https://github.com/azavea/pystac/workflows/CI/badge.svg?branch=develop)
 [![PyPI version](https://badge.fury.io/py/pystac.svg)](https://badge.fury.io/py/pystac)
 [![Documentation](https://readthedocs.org/projects/pystac/badge/?version=latest)](https://pystac.readthedocs.io/en/latest/)
 [![Gitter chat](https://badges.gitter.im/azavea/pystac.svg)](https://gitter.im/azavea/pystac)


### PR DESCRIPTION
Ensure that the CI workflow is triggered when changes are pushed to the `develop` and `master` branches. In addition, this scopes the GitHub Actions badge status to the `develop` branch.

Fixes https://github.com/azavea/pystac/issues/111

---

**Testing**

I haven't come up with a good way to test this. I think that the `develop` workflow has to be activated for the `.svg?branch=develop` badge to exist.