### PR TITLE
Minor fixes to Label extension docs

### DIFF
--- a/docs/tutorials/pystac-spacenet-tutorial.ipynb
+++ b/docs/tutorials/pystac-spacenet-tutorial.ipynb
@@ -271,7 +271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this step, we will add `LabelItems` to each scene Item. We will download these from the SpaceNet s3 bucket and save them locally. We will also create COGs of each geotiff and save them to the same directory as the labels."
+    "In this step, we will add `Items` with the `Label` extension to each scene Item. We will download these from the SpaceNet s3 bucket and save them locally. We will also create COGs of each geotiff and save them to the same directory as the labels."
    ]
   },
   {

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -65,7 +65,7 @@ class LabelItemExt(ItemExtension):
             label_classes (List[LabelClass]): Optional, but reqiured if ussing categorical data.
                 A list of LabelClasses defining the list of possible class names for each
                 label:properties. (e.g., tree, building, car, hippo)
-            label_tasks (str): Recommended to be a subset of 'regression', 'classification',
+            label_tasks (List[str]): Recommended to be a subset of 'regression', 'classification',
                 'detection', or 'segmentation', but may be an arbitrary value.
             label_methods: Recommended to be a subset of 'automated' or 'manual',
                 but may be an arbitrary value.


### PR DESCRIPTION
Straightforward upgrade to STAC 0.9.0 for a catalog utilizing the Label extension, thanks @lossyrob!

Here's two _very_ minor fixes to the docs that I noticed while doing our upgrade. 