### PR TITLE
Add the Projection extension.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added support for the Projection extension([#125](https://github.com/azavea/pystac/pull/125))
+
 ## [v0.4.0]
 
 The two major changes for this release are:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -250,6 +250,19 @@ LabelStatistics
    :members:
    :undoc-members:
 
+Projection Extension
+--------------------
+
+Implements the `Projection Extension <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/projection>`_.
+
+ProjectionItemExt
+~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.projection.ProjectionItemExt
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Single File STAC Extension
 --------------------------
 

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -32,12 +32,14 @@ from pystac import extensions
 import pystac.extensions.commons
 import pystac.extensions.eo
 import pystac.extensions.label
+import pystac.extensions.projection
 import pystac.extensions.view
 
 STAC_EXTENSIONS = extensions.base.RegisteredSTACExtensions([
     extensions.commons.COMMONS_EXTENSION_DEFINITION,
     extensions.eo.EO_EXTENSION_DEFINITION,
     extensions.label.LABEL_EXTENSION_DEFINITION,
+    extensions.projection.PROJECTION_EXTENSION_DEFINITION,
     extensions.view.VIEW_EXTENSION_DEFINITION,
 ])
 

--- a/pystac/extensions/__init__.py
+++ b/pystac/extensions/__init__.py
@@ -17,6 +17,7 @@ class Extensions:
     EO = 'eo'
     LABEL = 'label'
     POINTCLOUD = 'pointcloud'
+    PROJECTION = 'projection'
     SAR = 'sar'
     SCIENTIFIC = 'scientific'
     SINGLE_FILE_STAC = 'single-file-stac'

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -1,0 +1,237 @@
+from pystac import Extensions
+from pystac.item import Item
+from pystac.extensions.base import (ItemExtension, ExtensionDefinition, ExtendedObject)
+
+
+class ProjectionItemExt(ItemExtension):
+    """ProjectionItemExt is the extension of an Item in the Projection Extension.
+    The Projection extension adds projection information to STAC Items.
+
+    Args:
+        item (Item): The item to be extended.
+
+    Attributes:
+        item (Item): The Item that is being extended.
+
+    Note:
+        Using ProjectionItemExt to directly wrap an item will add the 'proj' extension ID to
+        the item's stac_extensions.
+    """
+    def __init__(self, item):
+        if item.stac_extensions is None:
+            item.stac_extensions = [Extensions.PROJECTION]
+        elif Extensions.PROJECTION not in item.stac_extensions:
+            item.stac_extensions.append(Extensions.PROJECTION)
+
+        self.item = item
+
+    def apply(self,
+              epsg,
+              wkt2=None,
+              projjson=None,
+              geometry=None,
+              bbox=None,
+              centroid=None,
+              shape=None,
+              transform=None):
+        """Applies Projection extension properties to the extended Item.
+
+        Args:
+            epsg (int or None): REQUIRED. EPSG code of the datasource.
+            wkt2 (str or None): WKT2 string representing the Coordinate Reference System (CRS) that
+                the ``geometry`` and ``bbox`` fields represent
+            projjson (dict or None): PROJJSON dict representing the
+                Coordinate Reference System (CRS) that the ``geometry`` and ``bbox``
+                fields represent
+            geometry (dict or None): GeoJSON Polygon dict that defines the footprint of this Item.
+            bbox (List[float] or None): Bounding box of the Item in the asset CRS in
+                2 or 3 dimensions.
+            centroid (dict or None): A dict with members 'lat' and 'lon' that defines
+                coordinates representing the centroid of the item in the asset data CRS.
+                Coordinates are defined in latitude and longitude, even if the data coordinate
+                system may not use lat/long.
+            shape (List[int] or None): Number of pixels in Y and X directions for the default grid.
+            transform (List[float] or None): The affine transformation coefficients for the
+                default grid
+        """
+        self.epsg = epsg
+        self.wkt2 = wkt2
+        self.projjson = projjson
+        self.geometry = geometry
+        self.bbox = bbox
+        self.centroid = centroid
+        self.shape = shape
+        self.transform = transform
+
+    @property
+    def epsg(self):
+        """Get or sets the EPSG code of the datasource.
+
+        A Coordinate Reference System (CRS) is the data reference system (sometimes called a
+        'projection') used by the asset data, and can usually be referenced using an
+        `EPSG code <http://epsg.io/>`_.
+        If the asset data does not have a CRS, such as in the case of non-rectified imagery with
+        Ground Control Points, epsg should be set to None.
+        It should also be set to null if a CRS exists, but for which there is no valid EPSG code.
+
+        Returns:
+            int
+        """
+        return self.item.properties.get('proj:epsg')
+
+    @epsg.setter
+    def epsg(self, v):
+        self.item.properties['proj:epsg'] = v
+
+    @property
+    def wkt2(self):
+        """Get or sets the WKT2 string representing the Coordinate Reference System (CRS)
+        that the proj:geometry and proj:bbox fields represent
+
+        This value is a `WKT2 string <http://docs.opengeospatial.org/is/12-063r5/12-063r5.html>`_.
+        If the data does not have a CRS, such as in the case of non-rectified imagery with Ground
+        Control Points, wkt2 should be set to null. It should also be set to null if a CRS exists,
+        but for which a WKT2 string does not exist.
+
+        Returns:
+            str
+        """
+        return self.item.properties.get('proj:wkt2')
+
+    @wkt2.setter
+    def wkt2(self, v):
+        self.item.properties['proj:wkt2'] = v
+
+    @property
+    def projjson(self):
+        """Get or sets the PROJJSON string representing the Coordinate Reference System (CRS)
+        that the proj:geometry and proj:bbox fields represent
+
+        This value is a `PROJJSON object <https://proj.org/specifications/projjson.html>`_.
+        If the data does not have a CRS, such as in the case of non-rectified imagery with Ground
+        Control Points, projjson should be set to null. It should also be set to null if a
+        CRS exists, but for which a PROJJSON string does not exist.
+
+        The schema for this object can be found
+        `here <https://proj.org/schemas/v0.2/projjson.schema.json>`_.
+
+        Returns:
+            dict
+        """
+        return self.item.properties.get('proj:projjson')
+
+    @projjson.setter
+    def projjson(self, v):
+        self.item.properties['proj:projjson'] = v
+
+    @property
+    def geometry(self):
+        """Get or sets a Polygon GeoJSON dict representing the footprint of this item.
+
+        This dict should be formatted according the Polygon object format specified in
+        `RFC 7946, sections 3.1.6 <https://tools.ietf.org/html/rfc7946>`_,
+        except not necessarily in EPSG:4326 as required by RFC7946. Specified based on the
+        ``epsg``, ``projjson`` or ``wkt2`` fields (not necessarily EPSG:4326).
+        Ideally, this will be represented by a Polygon with five coordinates, as the item in
+        the asset data CRS should be a square aligned to the original CRS grid.
+
+        Returns:
+            dict
+        """
+        return self.item.properties.get('proj:geometry')
+
+    @geometry.setter
+    def geometry(self, v):
+        self.item.properties['proj:geometry'] = v
+
+    @property
+    def bbox(self):
+        """Get or sets the bounding box of the assets represented by this item in the asset
+        data CRS.
+
+        Specified as 4 or 6 coordinates based on the CRS defined in the ``epsg``, ``projjson``
+        or ``wkt2`` properties. First two numbers are coordinates of the lower left corner,
+        followed by coordinates of upper right corner, e.g.,
+        [west, south, east, north], [xmin, ymin, xmax, ymax], [left, down, right, up],
+        or [west, south, lowest, east, north, highest]. The length of the array must be 2*n
+        where n is the number of dimensions.
+
+        Returns:
+            List[float]
+        """
+        return self.item.properties.get('proj:bbox')
+
+    @bbox.setter
+    def bbox(self, v):
+        self.item.properties['proj:bbox'] = v
+
+    @property
+    def centroid(self):
+        """Get or sets coordinates representing the centroid of the item in the asset data CRS.
+
+        Coordinates are defined in latitude and longitude, even if the data coordinate system
+        does not use lat/long.
+
+        Exmample::
+
+            item.ext.proj.centroid = { 'lat': 0.0, 'lon': 0.0 }
+
+        Returns:
+            dict
+        """
+        return self.item.properties.get('proj:centroid')
+
+    @centroid.setter
+    def centroid(self, v):
+        self.item.properties['proj:centroid'] = v
+
+    @property
+    def shape(self):
+        """Get or sets the number of pixels in Y and X directions for the default grid.
+
+        The shape is an array of integers that represents the number of pixels in the most
+        common pixel grid used by the item's assets. The number of pixels should be specified
+        in Y, X order. If the shape is defined in an item's properties it is used as the default
+        shape for all assets that don't have an overriding shape.
+
+        Returns:
+            List[int]
+        """
+        return self.item.properties.get('proj:shape')
+
+    @shape.setter
+    def shape(self, v):
+        self.item.properties['proj:shape'] = v
+
+    @property
+    def transform(self):
+        """Get or sets the the affine transformation coefficients for the default grid.
+
+        The transform is a linear mapping from pixel coordinate space (Pixel, Line) to
+        projection coordinate space (Xp, Yp). It is a 3x3 matrix stored as a flat array of 9
+        elements in row major order. Since the last row is always 0,0,1 it can be omitted, in
+        which case only 6 elements are recorded. This mapping can be obtained from
+        GDAL `GetGeoTransform <https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd>`_
+        or the
+        Rasterio `Transform <https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform>`_.
+
+        Returns:
+            float
+        """  # noqa: E501
+        return self.item.properties.get('proj:transform')
+
+    @transform.setter
+    def transform(self, v):
+        self.item.properties['proj:transform'] = v
+
+    @classmethod
+    def _object_links(cls):
+        return []
+
+    @classmethod
+    def from_item(cls, item):
+        return cls(item)
+
+
+PROJECTION_EXTENSION_DEFINITION = ExtensionDefinition(Extensions.PROJECTION,
+                                                      [ExtendedObject(Item, ProjectionItemExt)])

--- a/tests/data-files/projection/example-landsat8.json
+++ b/tests/data-files/projection/example-landsat8.json
@@ -1,0 +1,272 @@
+{
+    "stac_version": "1.0.0-beta.2",
+    "stac_extensions": [
+        "eo",
+        "projection"
+    ],
+    "id": "LC81530252014153LGN00",
+    "type": "Feature",
+    "collection": "landsat-8-l1",
+    "bbox": [
+        148.13933,
+        59.51584,
+        152.52758,
+        60.63437
+    ],
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    152.52758,
+                    60.63437
+                ],
+                [
+                    149.1755,
+                    61.19016
+                ],
+                [
+                    148.13933,
+                    59.51584
+                ],
+                [
+                    151.33786,
+                    58.97792
+                ],
+                [
+                    152.52758,
+                    60.63437
+                ]
+            ]
+        ]
+    },
+    "assets": {
+        "B1": {
+            "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B1.TIF",
+            "type": "image/tiff; application=geotiff",
+            "eo:bands": [
+                {
+                    "name": "B1",
+                    "common_name": "coastal",
+                    "center_wavelength": 0.44,
+                    "full_width_half_max": 0.02
+                }
+            ],
+            "title": "Band 1 (coastal)"
+        },
+        "B8": {
+            "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B8.TIF",
+            "type": "image/tiff; application=geotiff",
+            "eo:bands": [
+                {
+                    "name": "B8",
+                    "common_name": "panchromatic",
+                    "center_wavelength": 0.59,
+                    "full_width_half_max": 0.18
+                }
+            ],
+            "title": "Band 8 (panchromatic)",
+            "proj:shape": [
+                16781,
+                16621
+            ],
+            "proj:transform": [
+                15.0,
+                0.0,
+                224992.5,
+                0.0,
+                -15.0,
+                6790207.5,
+                0.0,
+                0.0,
+                1.0
+            ]
+        }
+    },
+    "properties": {
+        "datetime": "2018-10-01T01:08:32.033Z",
+        "proj:epsg": 32614,
+        "proj:wkt2": "PROJCS[\"WGS 84 / UTM zone 14N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-99],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],AUTHORITY[\"EPSG\",\"32614\"],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+        "proj:projjson": {
+            "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+            "type": "ProjectedCRS",
+            "name": "WGS 84 / UTM zone 14N",
+            "base_crs": {
+                "name": "WGS 84",
+                "datum": {
+                    "type": "GeodeticReferenceFrame",
+                    "name": "World Geodetic System 1984",
+                    "ellipsoid": {
+                        "name": "WGS 84",
+                        "semi_major_axis": 6378137,
+                        "inverse_flattening": 298.257223563
+                    }
+                },
+                "coordinate_system": {
+                    "subtype": "ellipsoidal",
+                    "axis": [
+                        {
+                            "name": "Geodetic latitude",
+                            "abbreviation": "Lat",
+                            "direction": "north",
+                            "unit": "degree"
+                        },
+                        {
+                            "name": "Geodetic longitude",
+                            "abbreviation": "Lon",
+                            "direction": "east",
+                            "unit": "degree"
+                        }
+                    ]
+                },
+                "id": {
+                    "authority": "EPSG",
+                    "code": 4326
+                }
+            },
+            "conversion": {
+                "name": "UTM zone 14N",
+                "method": {
+                    "name": "Transverse Mercator",
+                    "id": {
+                        "authority": "EPSG",
+                        "code": 9807
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "Latitude of natural origin",
+                        "value": 0,
+                        "unit": "degree",
+                        "id": {
+                            "authority": "EPSG",
+                            "code": 8801
+                        }
+                    },
+                    {
+                        "name": "Longitude of natural origin",
+                        "value": -99,
+                        "unit": "degree",
+                        "id": {
+                            "authority": "EPSG",
+                            "code": 8802
+                        }
+                    },
+                    {
+                        "name": "Scale factor at natural origin",
+                        "value": 0.9996,
+                        "unit": "unity",
+                        "id": {
+                            "authority": "EPSG",
+                            "code": 8805
+                        }
+                    },
+                    {
+                        "name": "False easting",
+                        "value": 500000,
+                        "unit": "metre",
+                        "id": {
+                            "authority": "EPSG",
+                            "code": 8806
+                        }
+                    },
+                    {
+                        "name": "False northing",
+                        "value": 0,
+                        "unit": "metre",
+                        "id": {
+                            "authority": "EPSG",
+                            "code": 8807
+                        }
+                    }
+                ]
+            },
+            "coordinate_system": {
+                "subtype": "Cartesian",
+                "axis": [
+                    {
+                        "name": "Easting",
+                        "abbreviation": "E",
+                        "direction": "east",
+                        "unit": "metre"
+                    },
+                    {
+                        "name": "Northing",
+                        "abbreviation": "N",
+                        "direction": "north",
+                        "unit": "metre"
+                    }
+                ]
+            },
+            "area": "World - N hemisphere - 102\u00b0W to 96\u00b0W - by country",
+            "bbox": {
+                "south_latitude": 0,
+                "west_longitude": -102,
+                "north_latitude": 84,
+                "east_longitude": -96
+            },
+            "id": {
+                "authority": "EPSG",
+                "code": 32614
+            }
+        },
+        "proj:geometry": {
+            "coordinates": [
+                [
+                    [
+                        169200.0,
+                        3712800.0
+                    ],
+                    [
+                        403200.0,
+                        3712800.0
+                    ],
+                    [
+                        403200.0,
+                        3951000.0
+                    ],
+                    [
+                        169200.0,
+                        3951000.0
+                    ],
+                    [
+                        169200.0,
+                        3712800.0
+                    ]
+                ]
+            ],
+            "type": "Polygon"
+        },
+        "proj:bbox": [
+            169200.0,
+            3712800.0,
+            403200.0,
+            3951000.0
+        ],
+        "proj:centroid": {
+            "lat": 34.595302781575604,
+            "lon": -101.34448382627504
+        },
+        "proj:shape": [
+            8391,
+            8311
+        ],
+        "proj:transform": [
+            30.0,
+            0.0,
+            224985.0,
+            0.0,
+            -30.0,
+            6790215.0,
+            0.0,
+            0.0,
+            1.0
+        ]
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://odu9mlf7d6.execute-api.us-east-1.amazonaws.com/stage/search?id=LC08_L1TP_107018_20181001_20181001_01_RT"
+        }
+    ]
+}

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -1,0 +1,223 @@
+import json
+import unittest
+
+import pystac
+from pystac.extensions import ExtensionError
+from pystac import (Item, Extensions)
+from tests.utils import (SchemaValidator, STACValidationError, TestCases, test_to_from_dict)
+
+WKT2 = """
+GEOGCS["WGS 84",
+    DATUM["WGS_1984",
+        SPHEROID["WGS 84",6378137,298.257223563,
+            AUTHORITY["EPSG","7030"]],
+        AUTHORITY["EPSG","6326"]],
+    PRIMEM["Greenwich",0,
+        AUTHORITY["EPSG","8901"]],
+    UNIT["degree",0.0174532925199433,
+        AUTHORITY["EPSG","9122"]],
+    AXIS["Latitude",NORTH],
+    AXIS["Longitude",EAST],
+    AUTHORITY["EPSG","4326"]]
+"""
+PROJJSON = json.loads("""
+{
+    "$schema": "https://proj.org/schemas/v0.1/projjson.schema.json",
+    "type": "GeographicCRS",
+    "name": "WGS 84",
+    "datum": {
+        "type": "GeodeticReferenceFrame",
+        "name": "World Geodetic System 1984",
+        "ellipsoid": {
+            "name": "WGS 84",
+            "semi_major_axis": 6378137,
+            "inverse_flattening": 298.257223563
+        }
+    },
+    "coordinate_system": {
+        "subtype": "ellipsoidal",
+        "axis": [
+        {
+            "name": "Geodetic latitude",
+            "abbreviation": "Lat",
+            "direction": "north",
+            "unit": "degree"
+        },
+        {
+            "name": "Geodetic longitude",
+            "abbreviation": "Lon",
+            "direction": "east",
+            "unit": "degree"
+        }
+        ]
+    },
+    "area": "World",
+    "bbox": {
+        "south_latitude": -90,
+        "west_longitude": -180,
+        "north_latitude": 90,
+        "east_longitude": 180
+    },
+    "id": {
+        "authority": "EPSG",
+        "code": 4326
+    }
+}
+""")
+
+
+class ProjectionTest(unittest.TestCase):
+    def setUp(self):
+        self.validator = SchemaValidator()
+        self.maxDiff = None
+        self.example_uri = TestCases.get_path('data-files/projection/example-landsat8.json')
+
+    def test_to_from_dict(self):
+        with open(self.example_uri) as f:
+            d = json.load(f)
+        test_to_from_dict(self, Item, d)
+
+    def test_apply(self):
+        item = next(TestCases.test_case_2().get_all_items())
+        with self.assertRaises(ExtensionError):
+            item.ext.proj
+
+        item.ext.enable(Extensions.PROJECTION)
+        item.ext.projection.apply(
+            4326,
+            wkt2=WKT2,
+            projjson=PROJJSON,
+            geometry=item.geometry,
+            bbox=item.bbox,
+            centroid={
+                'lat': 0.0,
+                'lon': 1.0
+            },
+            shape=[100, 100],
+            transform=[30.0, 0.0, 224985.0, 0.0, -30.0, 6790215.0, 0.0, 0.0, 1.0])
+
+    def test_validate_proj(self):
+        item = pystac.read_file(self.example_uri)
+        self.validator.validate_object(item)
+
+    def test_epsg(self):
+        proj_item = pystac.read_file(self.example_uri)
+
+        # Get
+        self.assertIn("proj:epsg", proj_item.properties)
+        proj_epsg = proj_item.ext.projection.epsg
+        self.assertEqual(proj_epsg, proj_item.properties['proj:epsg'])
+
+        # Set
+        proj_item.ext.projection.epsg = proj_epsg + 100
+        self.assertEqual(proj_epsg + 100, proj_item.properties['proj:epsg'])
+        self.validator.validate_object(proj_item)
+
+    def test_wkt2(self):
+        proj_item = pystac.read_file(self.example_uri)
+
+        # Get
+        self.assertIn("proj:wkt2", proj_item.properties)
+        proj_wkt2 = proj_item.ext.projection.wkt2
+        self.assertEqual(proj_wkt2, proj_item.properties['proj:wkt2'])
+
+        # Set
+        proj_item.ext.projection.wkt2 = WKT2
+        self.assertEqual(WKT2, proj_item.properties['proj:wkt2'])
+        self.validator.validate_object(proj_item)
+
+    def test_projjson(self):
+        proj_item = pystac.read_file(self.example_uri)
+
+        # Get
+        self.assertIn("proj:projjson", proj_item.properties)
+        proj_projjson = proj_item.ext.projection.projjson
+        self.assertEqual(proj_projjson, proj_item.properties['proj:projjson'])
+
+        # Set
+        proj_item.ext.projection.projjson = PROJJSON
+        self.assertEqual(PROJJSON, proj_item.properties['proj:projjson'])
+        self.validator.validate_object(proj_item)
+
+        # Ensure setting bad projjson fails validation
+        with self.assertRaises(STACValidationError):
+            proj_item.ext.projection.projjson = {"bad": "data"}
+            self.validator.validate_object(proj_item)
+
+    def test_geometry(self):
+        proj_item = pystac.read_file(self.example_uri)
+
+        # Get
+        self.assertIn("proj:geometry", proj_item.properties)
+        proj_geometry = proj_item.ext.projection.geometry
+        self.assertEqual(proj_geometry, proj_item.properties['proj:geometry'])
+
+        # Set
+        proj_item.ext.projection.geometry = proj_item.geometry
+        self.assertEqual(proj_item.geometry, proj_item.properties['proj:geometry'])
+        self.validator.validate_object(proj_item)
+
+        # Ensure setting bad geometry fails validation
+        with self.assertRaises(STACValidationError):
+            proj_item.ext.projection.geometry = {"bad": "data"}
+            self.validator.validate_object(proj_item)
+
+    def test_bbox(self):
+        proj_item = pystac.read_file(self.example_uri)
+
+        # Get
+        self.assertIn("proj:bbox", proj_item.properties)
+        proj_bbox = proj_item.ext.projection.bbox
+        self.assertEqual(proj_bbox, proj_item.properties['proj:bbox'])
+
+        # Set
+        proj_item.ext.projection.bbox = [1.0, 2.0, 3.0, 4.0]
+        self.assertEqual(proj_item.properties['proj:bbox'], [1.0, 2.0, 3.0, 4.0])
+        self.validator.validate_object(proj_item)
+
+    def test_centroid(self):
+        proj_item = pystac.read_file(self.example_uri)
+
+        # Get
+        self.assertIn("proj:centroid", proj_item.properties)
+        proj_centroid = proj_item.ext.projection.centroid
+        self.assertEqual(proj_centroid, proj_item.properties['proj:centroid'])
+
+        # Set
+        new_val = {'lat': 2.0, 'lon': 3.0}
+        proj_item.ext.projection.centroid = new_val
+        self.assertEqual(proj_item.properties['proj:centroid'], new_val)
+        self.validator.validate_object(proj_item)
+
+        # Ensure setting bad centroid fails validation
+        with self.assertRaises(STACValidationError):
+            proj_item.ext.projection.centroid = {'lat': 2.0, 'lng': 3.0}
+            self.validator.validate_object(proj_item)
+
+    def test_shape(self):
+        proj_item = pystac.read_file(self.example_uri)
+
+        # Get
+        self.assertIn("proj:shape", proj_item.properties)
+        proj_shape = proj_item.ext.projection.shape
+        self.assertEqual(proj_shape, proj_item.properties['proj:shape'])
+
+        # Set
+        new_val = [100, 200]
+        proj_item.ext.projection.shape = new_val
+        self.assertEqual(proj_item.properties['proj:shape'], new_val)
+        self.validator.validate_object(proj_item)
+
+    def test_transform(self):
+        proj_item = pystac.read_file(self.example_uri)
+
+        # Get
+        self.assertIn("proj:transform", proj_item.properties)
+        proj_transform = proj_item.ext.projection.transform
+        self.assertEqual(proj_transform, proj_item.properties['proj:transform'])
+
+        # Set
+        new_val = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        proj_item.ext.projection.transform = new_val
+        self.assertEqual(proj_item.properties['proj:transform'], new_val)
+        self.validator.validate_object(proj_item)

--- a/tests/utils/validator.py
+++ b/tests/utils/validator.py
@@ -29,6 +29,9 @@ class SchemaValidator:
         Extensions.EO: {
             STACObjectType.ITEM: 'extensions/eo/json-schema/schema.json'
         },
+        Extensions.PROJECTION: {
+            STACObjectType.ITEM: 'extensions/projection/json-schema/schema.json'
+        },
         Extensions.SINGLE_FILE_STAC: {
             # TODO: Move off of custom schema if schema in spec was fixed
             # before this extension got removed.
@@ -42,10 +45,11 @@ class SchemaValidator:
     aux_schemas = [
         'item-spec/json-schema/basics.json', 'item-spec/json-schema/datetime.json',
         'item-spec/json-schema/instrument.json', 'item-spec/json-schema/licensing.json',
-        'item-spec/json-schema/provider.json',
-        'https://geojson.org/schema/Geometry.json',
+        'item-spec/json-schema/provider.json', 'https://geojson.org/schema/Geometry.json',
         'https://geojson.org/schema/Feature.json',
-        'https://geojson.org/schema/FeatureCollection.json'
+        'https://geojson.org/schema/FeatureCollection.json',
+        'https://proj.org/schemas/v0.2/projjson.schema.json',
+        'https://geojson.org/schema/Polygon.json'
     ]
 
     _schema_cache = {}


### PR DESCRIPTION
This adds support for the [Projection extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/projection).

This PR:
- Adds the projection extension to the `pystac.extensions` package
- adds the extension identifier to `pystac.extensions.Extensions`
- registers the projection extension in the the top level `__init__.py`
- Adds unit tests for the extension, including modifying the STACValidator to validate against the extension
- Adds API docs for the extension
- Documents the change in the CHANGELOG