### PR TITLE
Fixup changes for 1.0.0 feature branch

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -105,7 +105,7 @@ Asset
    :undoc-members:
 
 CommonMetadata
-~~~~~
+~~~~~~~~~~~~~~
 
 .. autoclass:: pystac.CommonMetadata
    :members:
@@ -171,6 +171,10 @@ ExtensionError
 
 Extensions
 ----------
+
+.. autoclass:: pystac.extensions.Extensions
+   :members:
+   :undoc-members:
 
 ExtensionIndex
 ~~~~~~~~~~~~~~
@@ -256,7 +260,7 @@ Projection Extension
 Implements the `Projection Extension <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/projection>`_.
 
 ProjectionItemExt
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 .. autoclass:: pystac.extensions.projection.ProjectionItemExt
    :members:
@@ -274,6 +278,19 @@ SingleFileSTAC
 .. autoclass:: pystac.extensions.single_file_stac.SingleFileSTAC
    :members:
    :undoc-members:
+
+View Geometry Extension
+-----------------------
+
+Implements the `View Geometry Extension <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/view>`_.
+
+ViewItemExt
+~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.view.ViewItemExt
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Serialization
 -------------

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -44,7 +44,7 @@ class EOItemExt(ItemExtension):
         """Get or sets the Ground Sample Distance at the sensor.
 
         Returns:
-            [float]
+            float
         """
         return self.item.properties.get('eo:gsd')
 
@@ -58,7 +58,7 @@ class EOItemExt(ItemExtension):
             the available bands.
 
         Returns:
-            [List[Band]]
+            List[Band]
         """
         bands = self.item.properties.get('eo:bands')
         if bands is None:
@@ -75,7 +75,7 @@ class EOItemExt(ItemExtension):
             entire scene. If not available the field should not be provided.
 
         Returns:
-            [float or None]
+            float or None
         """
         return self.item.properties.get('eo:cloud_cover')
 
@@ -93,7 +93,7 @@ class EOItemExt(ItemExtension):
             asset [Asset]: The asset from the associated item to get the bands of.
 
         Returns:
-            [List[Band] or None]: A list of Band objects associated with the asset, or None
+            List[Band] or None: A list of Band objects associated with the asset, or None
             if the asset doesn't exist or does not contain band information.
         """
         if 'eo:bands' not in asset.properties:
@@ -203,7 +203,7 @@ class Band:
         """Get or sets the name of the band (e.g., "B01", "B02", "B1", "B5", "QA").
 
         Returns:
-            [str]
+            str
         """
         return self.properties.get('name')
 
@@ -218,7 +218,7 @@ class Band:
             <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
 
         Returns:
-            [str]
+            str
         """
         return self.properties.get('common_name')
 
@@ -235,7 +235,7 @@ class Band:
         used for rich text representation.
 
         Returns:
-            [str]
+            str
         """
         return self.properties.get('description')
 
@@ -251,7 +251,7 @@ class Band:
         """Get or sets the center wavelength of the band, in micrometers (μm).
 
         Returns:
-            [float]
+            float
         """
         return self.properties.get('center_wavelength')
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -87,7 +87,7 @@ class LabelItemExt(ItemExtension):
         and what it is recommended for.
 
         Returns:
-            [str]
+            str
         """
         return self.item.properties.get('label:description')
 
@@ -101,7 +101,7 @@ class LabelItemExt(ItemExtension):
         of :class:`~pystac.LabelType`).
 
         Returns:
-            [str]
+            str
         """
         return self.item.properties.get('label:type')
 
@@ -123,7 +123,7 @@ class LabelItemExt(ItemExtension):
         If labels are rasters, this should be None.
 
         Returns:
-            [List[str] or None]
+            List[str] or None
         """
         return self.item.properties.get('label:properties')
 
@@ -143,7 +143,7 @@ class LabelItemExt(ItemExtension):
         Optional, but reqiured if using categorical data.
 
         Returns:
-            [List[LabelClasses] or None]
+            List[LabelClasses] or None
         """
         label_classes = self.item.properties.get('label:classes')
         if label_classes is not None:
@@ -168,7 +168,7 @@ class LabelItemExt(ItemExtension):
             'classification', 'detection', or 'segmentation', but may be arbitrary values.
 
         Returns:
-            [List[str] or None]
+            List[str] or None
         """
         return self.item.properties.get('label:tasks')
 
@@ -188,7 +188,7 @@ class LabelItemExt(ItemExtension):
             but may be arbitrary values.
 
         Returns:
-            [List[str] or None]
+            List[str] or None
         """
         return self.item.properties.get('label:methods')
 
@@ -209,7 +209,7 @@ class LabelItemExt(ItemExtension):
         continuous numerical/regression data).
 
         Returns:
-            [List[LabelOverview] or None]
+            List[LabelOverview] or None
         """
         overviews = self.item.properties.get('label:overviews')
         if overviews is not None:
@@ -326,7 +326,7 @@ class LabelClasses:
                 class labels. If labels are raster-formatted, do not supply; required otherwise.
 
         Returns:
-            [LabelClasses]
+            LabelClasses
         """
         c = cls({})
         c.apply(classes, name)
@@ -337,7 +337,7 @@ class LabelClasses:
         """Get or sets the class values.
 
         Returns:
-            [List[str] or List[int] or List[float]]
+            List[str] or List[int] or List[float]
         """
         return self.properties.get('classes')
 
@@ -354,7 +354,7 @@ class LabelClasses:
         class labels. If labels are raster-formatted, do not supply; required otherwise.
 
         Returns:
-            [str]
+            str
         """
         return self.properties.get('name')
 
@@ -426,7 +426,7 @@ class LabelOverview:
         """Get or sets the property key within the asset corresponding to class labels.
 
         Returns:
-            [str]
+            str
         """
         return self.properties.get('property_key')
 
@@ -439,7 +439,7 @@ class LabelOverview:
         """Get or sets the list of LabelCounts containing counts for categorical data.
 
         Returns:
-            [List[LabelCount]]
+            List[LabelCount]
         """
         counts = self.properties.get('counts')
         if counts is not None:
@@ -462,7 +462,7 @@ class LabelOverview:
         regression/continuous numeric value data.
 
         Returns:
-            [List[Statistics]]
+            List[Statistics]
         """
         statistics = self.properties.get('statistics')
         if statistics is not None:
@@ -558,7 +558,7 @@ class LabelCount:
         """Get or sets the class that this count represents.
 
         Returns:
-            [str]
+            str
         """
         return self.properties.get('name')
 
@@ -571,7 +571,7 @@ class LabelCount:
         """Get or sets the number of occurences of the class.
 
         Returns:
-            [int]
+            int
         """
         return self.properties.get('count')
 
@@ -623,7 +623,7 @@ class LabelStatistics:
         """Get or sets the name of the statistic being reported.
 
         Returns:
-            [str]
+            str
         """
         return self.properties.get('name')
 
@@ -636,7 +636,7 @@ class LabelStatistics:
         """Get or sets the value of the statistic
 
         Returns:
-            [int or float]
+            int or float
         """
         return self.properties.get('value')
 

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -61,7 +61,7 @@ class ViewItemExt(ItemExtension):
         and the scene center. Measured in degrees (0-90).
 
         Returns:
-            [float]
+            float
         """
         return self.item.properties.get('view:off_nadir')
 
@@ -76,7 +76,7 @@ class ViewItemExt(ItemExtension):
         the scene center. Measured in degrees (0-90).
 
         Returns:
-            [float]
+            float
         """
         return self.item.properties.get('view:incidence_angle')
 
@@ -91,7 +91,7 @@ class ViewItemExt(ItemExtension):
         north. Measured clockwise from north in degrees (0-360).
 
         Returns:
-            [float]
+            float
         """
         return self.item.properties.get('view:azimuth')
 
@@ -105,7 +105,7 @@ class ViewItemExt(ItemExtension):
         is the angle between truth north and the sun. Measured clockwise in degrees (0-360).
 
         Returns:
-            [float]
+            float
         """
         return self.item.properties.get('view:sun_azimuth')
 
@@ -119,7 +119,7 @@ class ViewItemExt(ItemExtension):
         center point to the sun. Measured from the horizon in degrees (0-90).
 
         Returns:
-            [float]
+            float
         """
         return self.item.properties.get('view:sun_elevation')
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -528,7 +528,7 @@ class CommonMetadata:
         a Provider object or a dict but always stores each provider as a dict
 
         Returns:
-            [Provider]: List of organizations that captured or processed the data,
+            List[Provider]: List of organizations that captured or processed the data,
             encoded as Provider objects
         """
         providers = self.properties.get('providers')
@@ -561,7 +561,7 @@ class CommonMetadata:
         """Get or set the names of the instruments used
 
         Returns:
-            [str]: Name(s) of instrument(s) used
+            List[str]: Name(s) of instrument(s) used
         """
         return self.properties.get('instruments')
 

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0'
+__version__ = '0.5.0'
 """Library verison"""
 
 STAC_VERSION = '1.0.0-beta.2'

--- a/tests/data-files/change_stac_version.py
+++ b/tests/data-files/change_stac_version.py
@@ -6,21 +6,18 @@ import os
 import argparse
 import json
 
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Process some integers.')
-    parser.add_argument(
-        'stac_version',
-        metavar='STAC_VERSION',
-        help='The STAC_VERSION to ensure all STAC objects are using.')
+    parser.add_argument('stac_version',
+                        metavar='STAC_VERSION',
+                        help='The STAC_VERSION to ensure all STAC objects are using.')
 
     args = parser.parse_args()
 
     data_files_dir = os.path.dirname(os.path.realpath(__file__))
 
     # Skip examples directory, which contains version specific STACs...
-    dirs_to_check = [x for x in os.listdir(data_files_dir)
-                     if x != 'examples']
+    dirs_to_check = [x for x in os.listdir(data_files_dir) if x != 'examples']
 
     for d in dirs_to_check:
         for root, _, files in os.walk(d):
@@ -33,8 +30,7 @@ if __name__ == '__main__':
                         cur_ver = stac_json['stac_version']
                         if not cur_ver == args.stac_version:
                             print('Changing {} version from {} to {}...'.format(
-                                fname, cur_ver, args.stac_version
-                            ))
+                                fname, cur_ver, args.stac_version))
                             stac_json['stac_version'] = args.stac_version
                             with open(path, 'w') as f:
                                 json.dump(stac_json, f, indent=2)


### PR DESCRIPTION
Some small fixes:
- Set PySTAC version for next release to 0.5.0 (1.0.0 is targeted to happen once STAC 1.0.0 moves off of beta)
- Cleanup `Returns:` section of some pydocs
- Fix up extension docs
- Fix up some formatting