### PR TITLE
Refactor STAC_VERSION to get_stac_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added support for the Projection extension([#125](https://github.com/azavea/pystac/pull/125))
 - Add support for Item Asset properties ([#127](https://github.com/azavea/pystac/pull/127))
+- Added support for dynamically changing the STAC version via `pystac.set_stac_version` and `pystac.get_stac_version` ([#130](https://github.com/azavea/pystac/pull/130))
 
 ### Changed
 
@@ -20,6 +21,7 @@ asset extension renamed to item-assets and renamed assets field in Collections t
 
 - ItemCollection was removed. ([#123](https://github.com/azavea/pystac/pull/123))
 - The commons extension was removed. Collection properties will still be merged for pre-1.0.0-beta.1 items where appropriate ([#129](https://github.com/azavea/pystac/pull/129))
+- Removed `pystac.STAC_VERSION`. See addition of `get_stac_version` above. ([#130](https://github.com/azavea/pystac/pull/130))
 
 ## [v0.4.0]
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,7 +8,7 @@ pystac
 ------
 
 .. automodule:: pystac
-   :members: read_file, write_file, read_dict
+   :members: read_file, write_file, read_dict, set_stac_version, get_stac_version
 
 STACObject
 ----------

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -13,7 +13,7 @@ class STACError(Exception):
     pass
 
 
-from pystac.version import (__version__, STAC_VERSION)
+from pystac.version import (__version__, get_stac_version, set_stac_version)
 from pystac.stac_io import STAC_IO
 from pystac.extensions import Extensions
 from pystac.stac_object import STACObject

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -2,7 +2,7 @@ import os
 from copy import deepcopy
 
 import pystac
-from pystac import (STAC_VERSION, STACError)
+from pystac import STACError
 from pystac.stac_object import STACObject
 from pystac.link import (Link, LinkType)
 from pystac.cache import ResolvedObjectCache
@@ -307,7 +307,7 @@ class Catalog(STACObject):
 
         d = {
             'id': self.id,
-            'stac_version': STAC_VERSION,
+            'stac_version': pystac.get_stac_version(),
             'description': self.description,
             'links': [link.to_dict() for link in links]
         }

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -4,7 +4,7 @@ from copy import copy, deepcopy
 import dateutil.parser
 
 import pystac
-from pystac import (STAC_VERSION, STACError)
+from pystac import STACError
 from pystac.link import Link, LinkType
 from pystac.stac_object import STACObject
 from pystac.utils import (is_absolute_href, make_absolute_href, make_relative_href, datetime_to_str,
@@ -222,7 +222,7 @@ class Item(STACObject):
 
         d = {
             'type': 'Feature',
-            'stac_version': STAC_VERSION,
+            'stac_version': pystac.get_stac_version(),
             'id': self.id,
             'properties': self.properties,
             'geometry': self.geometry,

--- a/pystac/serialization/identify.py
+++ b/pystac/serialization/identify.py
@@ -1,4 +1,4 @@
-from pystac.version import STAC_VERSION
+from pystac.version import STACVersion
 from pystac.extensions import Extensions
 
 
@@ -34,9 +34,10 @@ class STACJSONDescription:
 
 
 class STACVersionRange:
-    def __init__(self, min_version='0.4.0', max_version=STAC_VERSION):
+    def __init__(self, min_version='0.4.0', max_version=None):
         self.min_version = min_version
-        self.max_version = max_version
+        if max_version is None:
+            self.max_version = STACVersion.DEFAULT_STAC_VERSION
 
     def set_min(self, v):
         if self.min_version < v:

--- a/pystac/serialization/migrate.py
+++ b/pystac/serialization/migrate.py
@@ -1,7 +1,7 @@
 import re
 from copy import deepcopy
 
-from pystac import STAC_VERSION
+from pystac.version import STACVersion
 from pystac.extensions import Extensions
 from pystac.serialization.identify import (STACObjectType, STACJSONDescription, STACVersionRange)
 
@@ -219,12 +219,12 @@ def migrate_to_latest(json_dict, info):
 
     Returns:
         dict: A copy of the dict that is migrated to the latest version (the
-        version that is pystac.STAC_VERSION)
+        version that is pystac.version.STACVersion.DEFAULT_STAC_VERSION)
     """
     result = deepcopy(json_dict)
     version = info.version_range.latest_valid_version()
 
-    if version != STAC_VERSION:
+    if version != STACVersion.DEFAULT_STAC_VERSION:
         _object_migrations[info.object_type](result, version, info)
 
         extensions_to_add = set([])
@@ -248,8 +248,9 @@ def migrate_to_latest(json_dict, info):
     else:
         common_extensions = info.common_extensions
 
-    result['stac_version'] = STAC_VERSION
+    result['stac_version'] = STACVersion.DEFAULT_STAC_VERSION
 
-    return result, STACJSONDescription(info.object_type,
-                                       STACVersionRange(STAC_VERSION, STAC_VERSION),
-                                       common_extensions, info.custom_extensions)
+    return result, STACJSONDescription(
+        info.object_type,
+        STACVersionRange(STACVersion.DEFAULT_STAC_VERSION, STACVersion.DEFAULT_STAC_VERSION),
+        common_extensions, info.custom_extensions)

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,5 +1,66 @@
+import os
+
 __version__ = '0.5.0'
 """Library verison"""
 
-STAC_VERSION = '1.0.0-beta.2'
-"""STAC version"""
+
+class STACVersion:
+    DEFAULT_STAC_VERSION = '1.0.0-beta.2'
+    """Latest STAC version supported by PySTAC"""
+
+    # Version that holds a user-set STAC version to use.
+    _override_version = None
+
+    OVERRIDE_VERSION_ENV_VAR = 'PYSTAC_STAC_VERSION_OVERRIDE'
+
+    @classmethod
+    def get_stac_version(cls):
+        if cls._override_version is not None:
+            return cls._override_version
+
+        env_version = os.environ.get(cls.OVERRIDE_VERSION_ENV_VAR)
+        if env_version is not None:
+            return env_version
+
+        return cls.DEFAULT_STAC_VERSION
+
+    @classmethod
+    def set_stac_version(cls, stac_version):
+        cls._override_version = stac_version
+
+
+def get_stac_version():
+    """Returns the STAC version PySTAC writes as the "stac_version" property for
+    any object it serializes into JSON.
+
+    If a call to ``set_stac_version`` was made, this will return the value it was called with.
+    Next it will check the environment for a PYSTAC_STAC_VERSION_OVERRIDE variable. Otherwise
+    it will return the latest STAC version that this version of PySTAC supports.
+
+    Returns:
+        str: The STAC Version PySTAC is set up to use.
+    """
+    return STACVersion.get_stac_version()
+
+
+def set_stac_version(stac_version):
+    """Sets the STAC version that PySTAC should use.
+
+    This is the version that will be set as the "stac_version" property
+    on any JSON STAC objects written by PySTAC. If set to None, the override version
+    will be cleared if previously set and the default or an override taken from the
+    environment will be used.
+
+    You can also set the environment variable PYSTAC_STAC_VERSION_OVERRIDE to override
+    the version.
+
+    Args:
+        stac_version (str): The STAC version to use instead of the latest STAC version that
+            PySTAC supports (described in STACVersion.DEFAULT_STAC_VERSION)
+
+    Note:
+        Setting the STAC version to something besides the default version will not effect
+        the format of STAC read or written; it will only override the ``stac_version`` property
+        of the objects being written. Setting this incorrectly can produce invalid STAC.
+    """
+    STACVersion.set_stac_version(stac_version)

--- a/tests/data-files/get_examples.py
+++ b/tests/data-files/get_examples.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryDirectory
 from subprocess import call
 from urllib.error import HTTPError
 
-from pystac import (STAC_VERSION, STAC_IO)
+import pystac
 from pystac.serialization import identify_stac_object, STACObjectType
 
 
@@ -22,7 +22,7 @@ def remove_bad_collection(js):
             if rel is not None and rel == 'collection':
                 href = link['href']
                 try:
-                    json.loads(STAC_IO.read_text(href))
+                    json.loads(pystac.STAC_IO.read_text(href))
                     filtered_links.append(link)
                 except (HTTPError, FileNotFoundError, json.decoder.JSONDecodeError):
                     print('===REMOVING UNREADABLE COLLECTION AT {}'.format(href))
@@ -42,7 +42,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     stac_repo = 'https://github.com/radiantearth/stac-spec'
-    stac_spec_tag = 'v{}'.format(STAC_VERSION)
+    stac_spec_tag = 'v{}'.format(pystac.get_stac_version())
 
     examples_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'examples'))
 
@@ -69,7 +69,7 @@ if __name__ == '__main__':
                             example_version = js.get('stac_version')
                         if example_version is not None and \
                            example_version > args.previous_version:
-                            relpath = '{}/{}'.format(STAC_VERSION,
+                            relpath = '{}/{}'.format(pystac.get_stac_version(),
                                                      path.replace('{}/'.format(tmp_dir), ''))
                             target_path = os.path.join(examples_dir, relpath)
 

--- a/tests/serialization/test_migrate.py
+++ b/tests/serialization/test_migrate.py
@@ -1,7 +1,7 @@
 import unittest
 
 import pystac
-from pystac import (STAC_IO, STAC_VERSION, STACObject)
+from pystac import (STAC_IO, STACObject)
 from pystac.cache import CollectionCache
 from pystac.serialization import (identify_stac_object, identify_stac_object_type,
                                   merge_common_properties, migrate_to_latest, STACObjectType)
@@ -31,7 +31,8 @@ class MigrateTest(unittest.TestCase):
                 migrated_info = identify_stac_object(migrated_d)
 
                 self.assertEqual(migrated_info.object_type, info.object_type)
-                self.assertEqual(migrated_info.version_range.latest_valid_version(), STAC_VERSION)
+                self.assertEqual(migrated_info.version_range.latest_valid_version(),
+                                 pystac.get_stac_version())
                 self.assertEqual(set(migrated_info.common_extensions), set(info.common_extensions))
                 self.assertEqual(set(migrated_info.custom_extensions), set(info.custom_extensions))
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+
+import pystac
+from tests.utils import TestCases
+
+
+class VersionTest(unittest.TestCase):
+    def test_override_stac_version_with_environ(self):
+        version = os.environ.get('PYSTAC_STAC_VERSION_OVERRIDE')
+
+        try:
+            override_version = '1.0.0-gamma.2'
+            os.environ['PYSTAC_STAC_VERSION_OVERRIDE'] = override_version
+            cat = TestCases.test_case_1()
+            d = cat.to_dict()
+            self.assertEqual(d['stac_version'], override_version)
+        finally:
+            if version is None:
+                del os.environ['PYSTAC_STAC_VERSION_OVERRIDE']
+            else:
+                os.environ['PYSTAC_STAC_VERSION_OVERRIDE'] = version
+
+    def test_override_stac_version_with_call(self):
+        version = pystac.get_stac_version()
+        try:
+            override_version = '1.0.0-delta.2'
+            pystac.set_stac_version(override_version)
+            cat = TestCases.test_case_1()
+            d = cat.to_dict()
+            self.assertEqual(d['stac_version'], override_version)
+        finally:
+            if version == pystac.version.STACVersion.DEFAULT_STAC_VERSION:
+                pystac.set_stac_version(None)
+            else:
+                pystac.set_stac_version(version)

--- a/tests/utils/validator.py
+++ b/tests/utils/validator.py
@@ -3,7 +3,8 @@ import json
 import jsonschema
 from jsonschema.validators import RefResolver
 
-from pystac import (STAC_VERSION, STAC_IO, Catalog, Collection, Item, Extensions)
+import pystac
+from pystac import (STAC_IO, Catalog, Collection, Item, Extensions)
 from pystac.serialization import STACObjectType
 
 
@@ -13,7 +14,7 @@ class STACValidationError(Exception):
 
 class SchemaValidator:
     REPO = 'https://schemas.stacspec.org'
-    TAG = 'v{}'.format(STAC_VERSION)
+    TAG = 'v{}'.format(pystac.get_stac_version())
     SCHEMA_BASE_URI = '{}/{}'.format(REPO, TAG)
 
     core_schemas = {


### PR DESCRIPTION
This allows STAC_VERSION to be dynamically set by the user through a call to `pystac.set_stac_version` or an environment variable.

Fixes #121