### PR TITLE
Ensure proper version ordering during identification and migration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## Unreleased
+## [v0.5.0]
 
 ### Added
 
 - Added support for the Projection extension([#125](https://github.com/azavea/pystac/pull/125))
 - Add support for Item Asset properties ([#127](https://github.com/azavea/pystac/pull/127))
 - Added support for dynamically changing the STAC version via `pystac.set_stac_version` and `pystac.get_stac_version` ([#130](https://github.com/azavea/pystac/pull/130))
+- Added support for prerelease versions in version comparisions for the `pystac.serialization.identify` package ([#138](https://github.com/azavea/pystac/pull/138))
 
 ### Changed
 

--- a/pystac/serialization/__init__.py
+++ b/pystac/serialization/__init__.py
@@ -2,7 +2,8 @@
 from pystac import (Catalog, Collection, Item, Extensions)
 
 from pystac.serialization.identify import (STACObjectType, STACJSONDescription, STACVersionRange,
-                                           identify_stac_object, identify_stac_object_type)
+                                           STACVersionID, identify_stac_object,
+                                           identify_stac_object_type)
 
 from pystac.serialization.common_properties import merge_common_properties
 from pystac.serialization.migrate import migrate_to_latest

--- a/pystac/serialization/common_properties.py
+++ b/pystac/serialization/common_properties.py
@@ -1,6 +1,7 @@
 from pystac import Collection
 from pystac.utils import make_absolute_href
 from pystac.stac_io import STAC_IO
+from pystac.serialization.identify import STACVersionID
 
 
 def merge_common_properties(item_dict, collection_cache=None, json_href=None):
@@ -27,7 +28,7 @@ def merge_common_properties(item_dict, collection_cache=None, json_href=None):
 
     # The commons extension was removed in 1.0.0-beta.1, so if this is an earlier STAC
     # item we don't have to bother with merging.
-    if stac_version is not None and not stac_version.startswith('0.'):
+    if stac_version is not None and STACVersionID(stac_version) > '0.9.0':
         return False
 
     # Check to see if this is a 0.9.0 item that

--- a/tests/serialization/test_identify.py
+++ b/tests/serialization/test_identify.py
@@ -5,6 +5,7 @@ from pystac import STAC_IO
 from pystac.cache import CollectionCache
 from pystac.serialization import (identify_stac_object, identify_stac_object_type,
                                   merge_common_properties, STACObjectType)
+from pystac.serialization.identify import (STACVersionRange, STACVersionID)
 
 from tests.utils import TestCases
 
@@ -37,3 +38,17 @@ class IdentifyTest(unittest.TestCase):
             self.assertEqual(set(actual.custom_extensions),
                              set(example['custom_extensions']),
                              msg=msg)
+
+
+class VersionTest(unittest.TestCase):
+    def test_version_ordering(self):
+        version_id = STACVersionID('1.0.0-beta.2')
+        self.assertTrue(version_id < '1.0.0')
+
+    def test_version_range_ordering(self):
+        version_range = STACVersionRange('0.9.0', '1.0.0-beta.2')
+        self.assertTrue(version_range.contains('1.0.0-beta.1'))
+        self.assertFalse(version_range.contains('1.0.0'))
+
+        version_range = STACVersionRange('0.9.0', '1.0.0-beta.1')
+        self.assertFalse(version_range.contains('1.0.0-beta.2'))


### PR DESCRIPTION
Identification and migration currently uses string ordering for comparison. This doesn't work when comparing version such as `1.0.0` and `1.0.0-beta.2`. This PR ensures that those orderings utilize a version object that understands pre-release versions.