### PR TITLE
Update PySTAC version to 0.5.0

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -252,16 +252,16 @@ This will validate against the latest set of JSON schemas hosted at https://sche
 Validating STAC JSON
 --------------------
 
-You can validate STAC JSON represented as a ``dict`` using the :meth:`pystac.validation.validate_json` method:
+You can validate STAC JSON represented as a ``dict`` using the :meth:`pystac.validation.validate_dict` method:
 
 .. code-block:: python
 
    import json
-   from pystac.validation import validate_json
+   from pystac.validation import validate_dict
 
    with open('/path/to/item.json') as f:
        js = json.load(f)
-   validate_json(js)
+   validate_dict(js)
 
 Using your own validator
 ------------------------

--- a/pystac/cache.py
+++ b/pystac/cache.py
@@ -145,7 +145,7 @@ class ResolvedObjectCache:
 
         Args:
             first (ResolvedObjectCache): The first cache to merge. This cache will be
-                the prefered cache for objects in the case of ID conflicts.
+                the preferred cache for objects in the case of ID conflicts.
             second (ResolvedObjectCache): The second cache to merge.
 
         Returns:

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -379,7 +379,7 @@ class Catalog(STACObject):
 
     def make_all_asset_hrefs_absolute(self):
         """Makes all the HREFs of assets belonging to items in this catalog
-        and all children to be absoluet, recursively.
+        and all children to be absolute, recursively.
         """
         for _, _, items in self.walk():
             for item in items:
@@ -515,7 +515,7 @@ class Catalog(STACObject):
         Args:
             item_mapper (Callable):   A function that takes in an item, and returns either
                 an item or list of items. The item that is passed into the item_mapper
-                is a copy, so the method can mutate it safetly.
+                is a copy, so the method can mutate it safely.
 
         Returns:
             Catalog: A full copy of this catalog, with items manipulated according
@@ -556,7 +556,7 @@ class Catalog(STACObject):
             asset_mapper (Callable): A function that takes in an key and an Asset, and returns
                either an Asset, a (key, Asset), or a dictionary of Assets with unique keys.
                The Asset that is passed into the item_mapper is a copy, so the method can
-               mutate it safetly.
+               mutate it safely.
 
         Returns:
             Catalog: A full copy of this catalog, with assets manipulated according

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -22,14 +22,14 @@ class ExtendedObject:
         if stac_object_class is Catalog:
             if not issubclass(extension_class, CatalogExtension):
                 raise ExtensionError(
-                    "Classes extending catalogs must inheret from CatalogExtension")
+                    "Classes extending catalogs must inherit from CatalogExtension")
         if stac_object_class is Collection:
             if not issubclass(extension_class, CollectionExtension):
                 raise ExtensionError(
-                    "Classes extending collections must inheret from CollectionExtension")
+                    "Classes extending collections must inherit from CollectionExtension")
         if stac_object_class is Item:
             if not issubclass(extension_class, ItemExtension):
-                raise ExtensionError("Classes extending item must inheret from ItemExtension")
+                raise ExtensionError("Classes extending item must inherit from ItemExtension")
 
         self.stac_object_class = stac_object_class
         self.extension_class = extension_class

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -235,7 +235,7 @@ class LabelItemExt(ItemExtension):
         """Adds a link to a source item.
 
         Args:
-            source_item (Item): Source imagery that the LabelItem applys to.
+            source_item (Item): Source imagery that the LabelItem applies to.
             title (str): Optional title for the link.
             assets (List[str]): Optional list of assets that deterime what
                 assets in the source item this label item data appliees to.
@@ -568,7 +568,7 @@ class LabelCount:
 
     @property
     def count(self):
-        """Get or sets the number of occurences of the class.
+        """Get or sets the number of occurrences of the class.
 
         Returns:
             int

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -136,7 +136,7 @@ class Item(STACObject):
         """Get this item's assets.
 
         Returns:
-            Dict[str, Asset]: A copy of the dictonary of this item's assets.
+            Dict[str, Asset]: A copy of the dictionary of this item's assets.
         """
         return dict(self.assets.items())
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -113,7 +113,7 @@ class Link:
         return href
 
     def get_absolute_href(self):
-        """Gets the aboslute href for this link, if possible.
+        """Gets the absolute href for this link, if possible.
 
         Returns:
             str: Returns this link's HREF. It attempts to derive an absolute HREF

--- a/pystac/serialization/migrate.py
+++ b/pystac/serialization/migrate.py
@@ -140,7 +140,7 @@ def _migrate_eo(d, version, info):
 
         # The way bands were declared in assets changed.
         # In 1.0.0-beta.1 they are inlined into assets as
-        # opposed to having indicies back into a property-level array.
+        # opposed to having indices back into a property-level array.
         if 'eo:bands' in d['properties']:
             bands = d['properties']['eo:bands']
             for asset in d['assets'].values():

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -16,6 +16,14 @@ class STACObjectType:
 
 
 class ExtensionIndex:
+    """Defines methods for accessing extension functionality.
+
+    To access a specific extension, use the __getitem__ on this class with the
+    extension ID::
+
+        # Access the "bands" property on the eo extension.
+        item.ext['eo'].bands
+    """
     def __init__(self, stac_object):
         self.stac_object = stac_object
 

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = '0.5.0-RC1'
+__version__ = '0.5.0'
 """Library version"""
 
 

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,7 +1,7 @@
 import os
 
 __version__ = '0.5.0-RC1'
-"""Library verison"""
+"""Library version"""
 
 
 class STACVersion:


### PR DESCRIPTION
This PR moves the PySTAC version from 0.5.0-RC1 to 0.5.0.

It also contains some small documentation fixes.