### PR TITLE
Use python unittest's checks to get better error messages on failure.

### DIFF
--- a/tests/serialization/test_identify.py
+++ b/tests/serialization/test_identify.py
@@ -42,7 +42,7 @@ class IdentifyTest(unittest.TestCase):
 
 class VersionTest(unittest.TestCase):
     def test_version_ordering(self):
-        self.assertTrue(STACVersionID('0.9.0') == STACVersionID('0.9.0'))
+        self.assertEqual(STACVersionID('0.9.0'), STACVersionID('0.9.0'))
         self.assertFalse(STACVersionID('0.9.0') < STACVersionID('0.9.0'))
         self.assertFalse(STACVersionID('0.9.0') != STACVersionID('0.9.0'))
         self.assertFalse(STACVersionID('0.9.0') > STACVersionID('0.9.0'))

--- a/tests/serialization/test_migrate.py
+++ b/tests/serialization/test_migrate.py
@@ -63,5 +63,5 @@ class MigrateTest(unittest.TestCase):
             TestCases.get_path('data-files/examples/0.9.0/extensions/asset/'
                                'examples/example-landsat8.json'))
 
-        self.assertTrue('item-assets' in collection.stac_extensions)
-        self.assertTrue('item_assets' in collection.extra_fields)
+        self.assertIn('item-assets', collection.stac_extensions)
+        self.assertIn('item_assets', collection.extra_fields)

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -35,7 +35,7 @@ class ValidateTest(unittest.TestCase):
                 with open(path) as f:
                     stac_json = json.load(f)
 
-                self.assertTrue(len(pystac.validation.validate_dict(stac_json)) == 0)
+                self.assertEqual(len(pystac.validation.validate_dict(stac_json)), 0)
             else:
                 with self.subTest(path):
                     with open(path) as f:
@@ -54,5 +54,5 @@ class ValidateTest(unittest.TestCase):
                             try:
                                 pystac.validation.validate_dict(stac_json)
                             except STACValidationError as e:
-                                self.assertTrue(isinstance(e.source, jsonschema.ValidationError))
+                                self.assertIsInstance(e.source, jsonschema.ValidationError)
                                 raise e


### PR DESCRIPTION
assertTrue(thing) -> assertEqual, assertIn, assertIsInstance