### PR TITLE
Add validation for an entire catalog

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -249,6 +249,12 @@ You can validate any :class:`~pystac.Catalog`, :class:`~pystac.Collection` or :c
 
 This will validate against the latest set of JSON schemas hosted at https://schemas.stacspec.org, including any extensions that the object extends. If there are validation errors, a :class:`~pystac.validation.STACValidationError` will be raised.
 
+You can also call :meth:`~pystac.Catalog.validate_all` on a Catalog or Collection to recursively walk through a catalog and validate all objects within it.
+
+.. code-block:: python
+
+   catalog.validate_all()
+
 Validating STAC JSON
 --------------------
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -505,6 +505,22 @@ class Catalog(STACObject):
         for child in self.get_children():
             yield from child.walk()
 
+    def validate_all(self):
+        """Validates each catalog, collection contained within this catalog.
+
+        Walks through the children and items of the catalog and validates each
+        stac object.
+
+        Raises:
+            STACValidationError: Raises this error on any item that is invalid.
+                Will raise on the first invalid stac object encountered.
+        """
+        self.validate()
+        for child in self.get_children():
+            child.validate_all()
+        for item in self.get_items():
+            item.validate()
+
     def _object_links(self):
         return ['child', 'item'] + (pystac.STAC_EXTENSIONS.get_extended_object_links(self))
 

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -37,13 +37,14 @@ def validate(stac_object):
     Raises:
         STACValidationError
     """
-    return validate_dict(stac_dict=stac_object.to_dict(),
-                         stac_object_type=stac_object.STAC_OBJECT_TYPE,
-                         stac_version=pystac.get_stac_version(),
-                         extensions=stac_object.stac_extensions)
+    validate_dict(stac_dict=stac_object.to_dict(),
+                  stac_object_type=stac_object.STAC_OBJECT_TYPE,
+                  stac_version=pystac.get_stac_version(),
+                  extensions=stac_object.stac_extensions,
+                  href=stac_object.get_self_href())
 
 
-def validate_dict(stac_dict, stac_object_type=None, stac_version=None, extensions=None):
+def validate_dict(stac_dict, stac_object_type=None, stac_version=None, extensions=None, href=None):
     """Validate a stac object serialized as JSON into a dict.
 
     This method delegates to the call to :meth:`pystac.validation.STACValidator.validate`
@@ -59,6 +60,7 @@ def validate_dict(stac_dict, stac_object_type=None, stac_version=None, extension
             this will use PySTAC's identification logic to identify the stac version
         extensions (List[str]): Extension IDs for this stac object. If not supplied,
             PySTAC's identification logic to identify the extensions.
+        href (str): Optional HREF of the STAC object being validated.
 
     Returns:
         List[Object]: List of return values from the validation calls for the
@@ -82,7 +84,7 @@ def validate_dict(stac_dict, stac_object_type=None, stac_version=None, extension
         extensions = info.common_extensions
 
     return RegisteredValidator.get_validator().validate(stac_dict, stac_object_type, stac_version,
-                                                        extensions)
+                                                        extensions, href)
 
 
 class RegisteredValidator:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 import pystac
 from pystac import (Catalog, Collection, CatalogType, LinkType, Item, Asset, MediaType, Extensions)
 from pystac.extensions.label import LabelClasses
+from pystac.validation import STACValidationError
 from pystac.utils import is_absolute_href
 from tests.utils import (TestCases, RANDOM_GEOM, RANDOM_BBOX, MockStacIO)
 
@@ -438,6 +439,27 @@ class CatalogTest(unittest.TestCase):
             read_cat = pystac.read_file(p)
             self.assertTrue('type' in read_cat.extra_fields)
             self.assertEqual(read_cat.extra_fields['type'], 'FeatureCollection')
+
+    def test_validate_all(self):
+        for cat in TestCases.all_test_catalogs():
+            with self.subTest(cat.id):
+                # If hrefs are not set, it will fail validation.
+                if cat.get_self_href() is None:
+                    cat.normalize_hrefs('/tmp')
+                cat.validate_all()
+
+        # Make one invalid, write it off, read it in, ensure it throws
+        cat = TestCases.test_case_1()
+        item = cat.get_item('area-1-1-labels', recursive=True)
+        item.geometry = {'type': 'INVALID', 'coordinates': 'NONE'}
+        with TemporaryDirectory() as tmp_dir:
+            cat.normalize_hrefs(tmp_dir)
+            cat.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
+
+            cat2 = pystac.read_file(os.path.join(tmp_dir, 'catalog.json'))
+
+            with self.assertRaises(STACValidationError):
+                cat2.validate_all()
 
     def test_set_hrefs_manually(self):
         catalog = TestCases.test_case_1()

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -56,3 +56,18 @@ class ValidateTest(unittest.TestCase):
                             except STACValidationError as e:
                                 self.assertIsInstance(e.source, jsonschema.ValidationError)
                                 raise e
+
+    def test_validate_error_contains_href(self):
+        # Test that the exception message contains the HREF of the object if available.
+        cat = TestCases.test_case_1()
+        item = cat.get_item('area-1-1-labels', recursive=True)
+        assert item.get_self_href() is not None
+
+        item.geometry = {'type': 'INVALID'}
+
+        with self.assertRaises(STACValidationError):
+            try:
+                item.validate()
+            except STACValidationError as e:
+                self.assertTrue(item.get_self_href() in str(e))
+                raise e


### PR DESCRIPTION
This adds a `validate_all` method to Catalogs and Collection which will walk through the entire catalog and validate all child catalogs and items.

This also adds the HREF to the STACValidationError exception message when available. This helps when validating an entire catalog so that it's clear which file is causing the exception.